### PR TITLE
GitHub: Update Repository Name (v2)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -79,7 +79,7 @@ body:
     id: terms
     attributes:
       label: Agree to Contributing Terms
-      description: By submitting this issue, you agree to follow our [Contributing Guidelines](CONTRIBUTING.md) and [Code of Conduct](CODE_OF_CONDUCT.md)
+      description: By submitting this issue, you agree to follow our [Contributing Guidelines](https://github.com/bachman-dev/wanikani-api-types/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/bachman-dev/wanikani-api-types/blob/main/CODE_OF_CONDUCT.md)
       options:
         - label: I agree to follow this project's Contributing Guidelines and Code of Conduct
           required: true

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -79,7 +79,7 @@ body:
     id: terms
     attributes:
       label: Agree to Contributing Terms
-      description: By submitting this issue, you agree to follow our [Contributing Guidelines](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CODE_OF_CONDUCT.md)
+      description: By submitting this issue, you agree to follow our [Contributing Guidelines](CONTRIBUTING.md) and [Code of Conduct](CODE_OF_CONDUCT.md)
       options:
         - label: I agree to follow this project's Contributing Guidelines and Code of Conduct
           required: true

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -60,7 +60,7 @@ body:
     id: terms
     attributes:
       label: Agree to Contributing Terms
-      description: By submitting this issue, you agree to follow our [Contributing Guidelines](CONTRIBUTING.md) and [Code of Conduct](CODE_OF_CONDUCT.md)
+      description: By submitting this issue, you agree to follow our [Contributing Guidelines](https://github.com/bachman-dev/wanikani-api-types/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/bachman-dev/wanikani-api-types/blob/main/CODE_OF_CONDUCT.md)
       options:
         - label: I agree to follow this project's Contributing Guidelines and Code of Conduct
           required: true

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -60,7 +60,7 @@ body:
     id: terms
     attributes:
       label: Agree to Contributing Terms
-      description: By submitting this issue, you agree to follow our [Contributing Guidelines](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CODE_OF_CONDUCT.md)
+      description: By submitting this issue, you agree to follow our [Contributing Guidelines](CONTRIBUTING.md) and [Code of Conduct](CODE_OF_CONDUCT.md)
       options:
         - label: I agree to follow this project's Contributing Guidelines and Code of Conduct
           required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -36,5 +36,5 @@ Or some other information pertaining to the PR like breaking tests, etc.
 
 I understand that by submitting this Pull Request:
 
-- I agree to the terms outlined in the [Contribution Guidelines](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CODE_OF_CONDUCT.md)
-- My code will be licensed for use in this repository per its [LICENSE](https://github.com/bachmacintosh/wanikani-api-types/blob/main/LICENSE), and that I have the right to license this code -- per GitHub's [Terms of Service](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service#6-contributions-under-repository-license)
+- I agree to the terms outlined in the [Contribution Guidelines](CONTRIBUTING.md) and [Code of Conduct](CODE_OF_CONDUCT.md)
+- My code will be licensed for use in this repository per its [LICENSE](LICENSE), and that I have the right to license this code -- per GitHub's [Terms of Service](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service#6-contributions-under-repository-license)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -36,5 +36,5 @@ Or some other information pertaining to the PR like breaking tests, etc.
 
 I understand that by submitting this Pull Request:
 
-- I agree to the terms outlined in the [Contribution Guidelines](CONTRIBUTING.md) and [Code of Conduct](CODE_OF_CONDUCT.md)
-- My code will be licensed for use in this repository per its [LICENSE](LICENSE), and that I have the right to license this code -- per GitHub's [Terms of Service](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service#6-contributions-under-repository-license)
+- I agree to the terms outlined in the [Contribution Guidelines](https://github.com/bachman-dev/wanikani-api-types/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/bachman-dev/wanikani-api-types/blob/main/CODE_OF_CONDUCT.md)
+- My code will be licensed for use in this repository per its [LICENSE](https://github.com/bachman-dev/wanikani-api-types/blob/main/LICENSE), and that I have the right to license this code -- per GitHub's [Terms of Service](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service#6-contributions-under-repository-license)

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,5 +1,6 @@
 name: Tests (PR)
 on:
+  merge_group:
   pull_request:
     branches:
       - main

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # @bachmacintosh/wanikani-api-types
 
-[![Tests (Main)](https://github.com/bachmacintosh/wanikani-api-types/actions/workflows/push.yml/badge.svg)](https://github.com/bachmacintosh/wanikani-api-types/actions/workflows/push.yml)
-[![codecov](https://codecov.io/gh/bachmacintosh/wanikani-api-types/branch/main/graph/badge.svg?token=CCVBE1UM9M)](https://codecov.io/gh/bachmacintosh/wanikani-api-types)
+[![Tests (Main)](https://github.com/bachman-dev/wanikani-api-types/actions/workflows/push.yml/badge.svg)](https://github.com/bachman-dev/wanikani-api-types/actions/workflows/push.yml)
+[![codecov](https://codecov.io/gh/bachman-dev/wanikani-api-types/branch/main/graph/badge.svg?token=CCVBE1UM9M)](https://codecov.io/gh/bachman-dev/wanikani-api-types)
 
 Regularly updated type definitions for the [WaniKani API](https://docs.api.wanikani.com/20170710/)
 
@@ -150,7 +150,7 @@ When working with WaniKani's Subjects, you may want to stylize/highlight the mar
 
 ### Examples
 
-See [EXAMPLES.md](https://github.com/bachmacintosh/wanikani-api-types/blob/main/EXAMPLES.md) for examples using this library.
+See [EXAMPLES.md](EXAMPLES.md) for examples using this library.
 
 ## Need Help? Want to Contribute?
 
@@ -160,7 +160,7 @@ That said, if you have any questions or encounter any problems with this package
 
 We welcome any contributions to help improve this library. Please see the following documents:
 
-- [CONTRIBUTING.md](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CONTRIBUTING.md)
-- [CODE_OF_CONDUCT.md](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CODE_OF_CONDUCT.md)
+- [CONTRIBUTING.md](CONTRIBUTING.md)
+- [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)
 
 Thank you in advance for your contribution(s)!

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/bachmacintosh/wanikani-api-types"
+    "url": "https://github.com/bachman-dev/wanikani-api-types"
   },
   "dependencies": {
     "valibot": "1.0.0-rc.3"

--- a/typedoc.json
+++ b/typedoc.json
@@ -3,7 +3,7 @@
   "entryPoints": ["./src/v20170710.ts", "./src/index.ts"],
   "out": "docs",
   "plugin": ["./typedoc/plugin.js"],
-  "sourceLinkTemplate": "https://github.com/bachmacintosh/wanikani-api-types/blob/{gitRevision}/{path}#L{line}",
+  "sourceLinkTemplate": "https://github.com/bachman-dev/wanikani-api-types/blob/{gitRevision}/{path}#L{line}",
   "cleanOutputDir": true,
   "includeVersion": true,
   "categorizeByGroup": false,


### PR DESCRIPTION
# Description

This PR updates the repository name on the `v2` branch, similar to what was done on the `main` branch.

# Related Issue(s) / Pull Request(s)

#420 

# Nature of Pull Request

This Pull Request:

- [ ] Adds/Updates Type(s) described in the WaniKani API Docs
- [ ] Adds/Updates Type(s) provided by the `wanikani-api-types` package itself
- [ ] Adds/Updates constants or other variables provided by the package
- [ ] Adds/Updates Helper Functions/Type Guards provided by the package
- [ ] Updates Documentation
- [x] Updates Project and/or Community Health files (e.g. README, GitHub Actions, etc.)

Its changes constitutes a:

- [x] Non-code change (i.e. no version bump)
- [ ] Bug Fix or Other Small Changes (i.e. patch version bump)
- [ ] Forward-compatible Enhancement (i.e. minor version bump)
- [ ] ⚠️ BREAKING CHANGE regarding TypeScript, Package, and/or WaniKani API version(s) (i.e. MAJOR version bump)

# Additional Info

None

# Contribution Terms

I understand that by submitting this Pull Request:

- I agree to the terms outlined in the [Contribution Guidelines](CONTRIBUTING.md) and [Code of Conduct](CODE_OF_CONDUCT.md)
- My code will be licensed for use in this repository per its [LICENSE](LICENSE), and that I have the right to license this code -- per GitHub's [Terms of Service](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service#6-contributions-under-repository-license)
