### PR TITLE
Fix: Trim DatableString

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bachmacintosh/wanikani-api-types",
-  "version": "2.0.0-alpha.0",
+  "version": "2.0.0-alpha.1",
   "description": "Regularly updated type definitions for the WaniKani API",
   "keywords": [
     "wanikani",

--- a/src/base/v20170710.ts
+++ b/src/base/v20170710.ts
@@ -35,7 +35,7 @@ export function isApiRevision(value: unknown): value is ApiRevision {
  * @category Base
  */
 export type DatableString = v.Brand<"DatableString"> & string;
-export const DatableString = v.pipe(v.string(), v.isoTimestamp(), v.brand("DatableString"));
+export const DatableString = v.pipe(v.string(), v.trim(), v.isoTimestamp(), v.brand("DatableString"));
 
 /**
  * Validates that a string is a well-formatted ISO-8601 dat string.


### PR DESCRIPTION
# Description

This PR adds a trim action to the `DatableString` schema, to cover an edge case where it may contain leading/trailing whitespace/line terminators.

# Related Issue(s) / Pull Request(s)

None

# Nature of Pull Request

This Pull Request:

- [ ] Adds/Updates Type(s) described in the WaniKani API Docs
- [x] Adds/Updates Type(s) provided by the `wanikani-api-types` package itself
- [ ] Adds/Updates constants or other variables provided by the package
- [ ] Adds/Updates Helper Functions/Type Guards provided by the package
- [ ] Updates Documentation
- [ ] Updates Project and/or Community Health files (e.g. README, GitHub Actions, etc.)

Its changes constitutes a:

- [ ] Non-code change (i.e. no version bump)
- [x] Bug Fix or Other Small Changes (i.e. patch version bump)
- [ ] Forward-compatible Enhancement (i.e. minor version bump)
- [ ] ⚠️ BREAKING CHANGE regarding TypeScript, Package, and/or WaniKani API version(s) (i.e. MAJOR version bump)

# Additional Info

None

# Contribution Terms

I understand that by submitting this Pull Request:

- I agree to the terms outlined in the [Contribution Guidelines](https://github.com/bachman-dev/wanikani-api-types/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/bachman-dev/wanikani-api-types/blob/main/CODE_OF_CONDUCT.md)
- My code will be licensed for use in this repository per its [LICENSE](https://github.com/bachman-dev/wanikani-api-types/blob/main/LICENSE), and that I have the right to license this code -- per GitHub's [Terms of Service](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service#6-contributions-under-repository-license)
