### PR TITLE
BREAKING: Remove WK_ from WK_SUBJECT_MARKUP_MATCHERS

### DIFF
--- a/src/v20170710/subjects.ts
+++ b/src/v20170710/subjects.ts
@@ -732,7 +732,7 @@ export function isSubjectCollection(value: unknown): value is SubjectCollection 
  * @see {@link https://docs.api.wanikani.com/20170710/#subjects}
  * @category Subjects
  */
-export const WK_SUBJECT_MARKUP_MATCHERS = {
+export const SUBJECT_MARKUP_MATCHERS = {
   /**
    * A regular expression literal that matches to Japanese text surrounded by `<ja>` tags.
    */

--- a/tests/v20170710/subjects.test.ts
+++ b/tests/v20170710/subjects.test.ts
@@ -102,7 +102,7 @@ describe("SubjectParameters", () => {
 describe("WK_SUBJECT_MARKUP_MATCHERS", () => {
   testFor("Matches Japanese text highlighting in <ja> tags", () => {
     const testString = `The romaji "ka" can be written as <ja>か</ja> in hiragana. The romaji "setsu" can be written as <ja>せつ</ja>.`;
-    const matchedText = [...testString.matchAll(WK.WK_SUBJECT_MARKUP_MATCHERS.ja)];
+    const matchedText = [...testString.matchAll(WK.SUBJECT_MARKUP_MATCHERS.ja)];
     expect(matchedText).toHaveLength(2);
     expect(matchedText[0]?.[0]).toBe("<ja>か</ja>");
     expect(matchedText[0]?.groups?.innerText).toBe("か");
@@ -112,7 +112,7 @@ describe("WK_SUBJECT_MARKUP_MATCHERS", () => {
 
   testFor("Matches Kanji highlighting in <kanji> tags", () => {
     const testString = `Two of WaniKani's Level 1 Kanji are <kanji>山</kanji> and <kanji>人</kanji>.`;
-    const matchedText = [...testString.matchAll(WK.WK_SUBJECT_MARKUP_MATCHERS.kanji)];
+    const matchedText = [...testString.matchAll(WK.SUBJECT_MARKUP_MATCHERS.kanji)];
     expect(matchedText).toHaveLength(2);
     expect(matchedText[0]?.[0]).toBe("<kanji>山</kanji>");
     expect(matchedText[0]?.groups?.innerText).toBe("山");
@@ -122,7 +122,7 @@ describe("WK_SUBJECT_MARKUP_MATCHERS", () => {
 
   testFor("Matches Meaning highlighting in <meaning> tags", () => {
     const testString = `The kanji 一 means <meaning>one</meaning>. The kanji 二 means <meaning>two</meaning>.`;
-    const matchedText = [...testString.matchAll(WK.WK_SUBJECT_MARKUP_MATCHERS.meaning)];
+    const matchedText = [...testString.matchAll(WK.SUBJECT_MARKUP_MATCHERS.meaning)];
     expect(matchedText).toHaveLength(2);
     expect(matchedText[0]?.[0]).toBe("<meaning>one</meaning>");
     expect(matchedText[0]?.groups?.innerText).toBe("one");
@@ -132,7 +132,7 @@ describe("WK_SUBJECT_MARKUP_MATCHERS", () => {
 
   testFor("Matches Radical highlighting in <radical> tags", () => {
     const testString = `One of the first radicals is the <radical>ground</radical> radical. A more complex one is <radical>coat rack</radical>.`;
-    const matchedText = [...testString.matchAll(WK.WK_SUBJECT_MARKUP_MATCHERS.radical)];
+    const matchedText = [...testString.matchAll(WK.SUBJECT_MARKUP_MATCHERS.radical)];
     expect(matchedText).toHaveLength(2);
     expect(matchedText[0]?.[0]).toBe("<radical>ground</radical>");
     expect(matchedText[0]?.groups?.innerText).toBe("ground");
@@ -142,7 +142,7 @@ describe("WK_SUBJECT_MARKUP_MATCHERS", () => {
 
   testFor("Matches Reading highlighting in <reading> tags", () => {
     const testString = `The partical は can sound like <reading>ha</reading>, but is also read like <reading>wa</reading>.`;
-    const matchedText = [...testString.matchAll(WK.WK_SUBJECT_MARKUP_MATCHERS.reading)];
+    const matchedText = [...testString.matchAll(WK.SUBJECT_MARKUP_MATCHERS.reading)];
     expect(matchedText).toHaveLength(2);
     expect(matchedText[0]?.[0]).toBe("<reading>ha</reading>");
     expect(matchedText[0]?.groups?.innerText).toBe("ha");
@@ -152,7 +152,7 @@ describe("WK_SUBJECT_MARKUP_MATCHERS", () => {
 
   testFor("Matches Vocabulary highlighting in <vocabulary> tags", () => {
     const testString = `The kanji 一 is used in the vocabulary <vocabulary>one thing</vocabulary> and <vocabulary>first floor</vocabulary>.`;
-    const matchedText = [...testString.matchAll(WK.WK_SUBJECT_MARKUP_MATCHERS.vocabulary)];
+    const matchedText = [...testString.matchAll(WK.SUBJECT_MARKUP_MATCHERS.vocabulary)];
     expect(matchedText).toHaveLength(2);
     expect(matchedText[0]?.[0]).toBe("<vocabulary>one thing</vocabulary>");
     expect(matchedText[0]?.groups?.innerText).toBe("one thing");


### PR DESCRIPTION
# Description

This PR renames `WK_SUBJECT_MARKUP_MATCHERS` to `SUBJECT_MARKUP_MATCHERS`, to conform with the rest of the library having the WK prefix removed. We missed it on previous rename PRs.

# Related Issue(s) / Pull Request(s)

None

# Nature of Pull Request

This Pull Request:

- [ ] Adds/Updates Type(s) described in the WaniKani API Docs
- [ ] Adds/Updates Type(s) provided by the `wanikani-api-types` package itself
- [x] Adds/Updates constants or other variables provided by the package
- [x] Adds/Updates Helper Functions/Type Guards provided by the package
- [x] Updates Documentation
- [ ] Updates Project and/or Community Health files (e.g. README, GitHub Actions, etc.)

Its changes constitutes a:

- [ ] Non-code change (i.e. no version bump)
- [ ] Bug Fix or Other Small Changes (i.e. patch version bump)
- [ ] Forward-compatible Enhancement (i.e. minor version bump)
- [x] ⚠️ BREAKING CHANGE regarding TypeScript, Package, and/or WaniKani API version(s) (i.e. MAJOR version bump)

# Additional Info

None

# Contribution Terms

I understand that by submitting this Pull Request:

- I agree to the terms outlined in the [Contribution Guidelines](https://github.com/bachman-dev/wanikani-api-types/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/bachman-dev/wanikani-api-types/blob/main/CODE_OF_CONDUCT.md)
- My code will be licensed for use in this repository per its [LICENSE](https://github.com/bachman-dev/wanikani-api-types/blob/main/LICENSE), and that I have the right to license this code -- per GitHub's [Terms of Service](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service#6-contributions-under-repository-license)
