### PR TITLE
Docs: Add Cloudflare Router and Use Cloudflare Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,9 +1,9 @@
-name: Tests (Main)
+name: Docs
 on: workflow_dispatch
 jobs:
   test:
     name: "Rebuild and Deploy Docs"
     runs-on: ubuntu-latest
     steps:
-      - name: Trigger Vercel Deploy Hook
-        run: "curl -X POST ${{ secrets.VERCEL_DEPLOY_HOOK }}"
+      - name: Trigger Cloudflare Deploy Hook
+        run: "curl -X POST ${{ secrets.CLOUDFLARE_DEPLOY_HOOK }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Tests (Main)
+name: Release
 on:
   release:
     types: [published]
@@ -44,4 +44,4 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
       - name: Publish Documentation
-        run: "curl -X POST ${{ secrets.VERCEL_DEPLOY_HOOK }}"
+        run: "curl -X POST ${{ secrets.CLOUDFLARE_DEPLOY_HOOK }}"

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "prettier": "3.5.3",
     "rimraf": "6.0.1",
     "tsup": "8.4.0",
-    "typedoc": "0.28.0-beta.2",
+    "typedoc": "0.28.0",
     "typescript": "5.8.2",
     "typescript-eslint": "8.26.0",
     "vitest": "3.0.8"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bachmacintosh/wanikani-api-types",
-  "version": "2.0.0-alpha.2",
+  "version": "2.0.0-beta.0",
   "description": "Regularly updated type definitions for the WaniKani API",
   "keywords": [
     "wanikani",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "prettier": "3.5.3",
     "rimraf": "6.0.1",
     "tsup": "8.4.0",
-    "typedoc": "0.27.9",
+    "typedoc": "0.28.0-beta.2",
     "typescript": "5.8.2",
     "typescript-eslint": "8.26.0",
     "vitest": "3.0.8"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,8 +37,8 @@ importers:
         specifier: 8.4.0
         version: 8.4.0(@microsoft/api-extractor@7.48.0(@types/node@22.2.0))(postcss@8.4.41)(typescript@5.8.2)(yaml@2.7.0)
       typedoc:
-        specifier: 0.28.0-beta.2
-        version: 0.28.0-beta.2(typescript@5.8.2)
+        specifier: 0.28.0
+        version: 0.28.0(typescript@5.8.2)
       typescript:
         specifier: 5.8.2
         version: 5.8.2
@@ -408,8 +408,8 @@ packages:
     resolution: {integrity: sha512-JubJ5B2pJ4k4yGxaNLdbjrnk9d/iDz6/q8wOilpIowd6PJPgaxCuHBnBszq7Ce2TyMrywm5r4PnKm6V3iiZF+g==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@gerrit0/mini-shiki@3.1.0':
-    resolution: {integrity: sha512-ATE2iExp2tOYU1ANeGvxNFyc0slbxQBM6/KCHsAn0JHB7PC3AG/8y3d6Jdz9IVRpE+t9GmpjB5UiZT9EuuJG4w==}
+  '@gerrit0/mini-shiki@3.2.1':
+    resolution: {integrity: sha512-HbzRC6MKB6U8kQhczz0APKPIzFHTrcqhaC7es2EXInq1SpjPVnpVSIsBe6hNoLWqqCx1n5VKiPXq6PfXnHZKOQ==}
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -603,11 +603,11 @@ packages:
   '@rushstack/ts-command-line@4.23.1':
     resolution: {integrity: sha512-40jTmYoiu/xlIpkkRsVfENtBq4CW3R4azbL0Vmda+fMwHWqss6wwf/Cy/UJmMqIzpfYc2OTnjYP1ZLD3CmyeCA==}
 
-  '@shikijs/engine-oniguruma@3.1.0':
-    resolution: {integrity: sha512-reRgy8VzDPdiDocuGDD60Rk/jLxgcgy+6H4n6jYLeN2Yw5ikasRjQQx8ERXtDM35yg2v/d6KolDBcK8hYYhcmw==}
+  '@shikijs/engine-oniguruma@3.2.1':
+    resolution: {integrity: sha512-wZZAkayEn6qu2+YjenEoFqj0OyQI64EWsNR6/71d1EkG4sxEOFooowKivsWPpaWNBu3sxAG+zPz5kzBL/SsreQ==}
 
-  '@shikijs/types@3.1.0':
-    resolution: {integrity: sha512-F8e7Fy4ihtcNpJG572BZZC1ErYrBrzJ5Cbc9Zi3REgWry43gIvjJ9lFAoUnuy7Bvy4IFz7grUSxL5edfrrjFEA==}
+  '@shikijs/types@3.2.1':
+    resolution: {integrity: sha512-/NTWAk4KE2M8uac0RhOsIhYQf4pdU0OywQuYDGIGAJ6Mjunxl2cGiuLkvu4HLCMn+OTTLRWkjZITp+aYJv60yA==}
 
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
@@ -1581,8 +1581,8 @@ packages:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
 
-  typedoc@0.28.0-beta.2:
-    resolution: {integrity: sha512-+7YrRafvYClYuQqhWUvUkUAB/eD7Jh1gls/PVeCOInz3MeOYnl8H76EnnMp7kiXeNV35GwP3foVbNCaxyO8OFg==}
+  typedoc@0.28.0:
+    resolution: {integrity: sha512-UU+xxZXrpnUhEulBYRwY2afoYFC24J2fTFovOs3llj2foGShCoKVQL6cQCfQ+sBAOdiFn2dETpZ9xhah+CL3RQ==}
     engines: {node: '>= 18', pnpm: '>= 10'}
     hasBin: true
     peerDependencies:
@@ -1949,10 +1949,10 @@ snapshots:
       '@eslint/core': 0.12.0
       levn: 0.4.1
 
-  '@gerrit0/mini-shiki@3.1.0':
+  '@gerrit0/mini-shiki@3.2.1':
     dependencies:
-      '@shikijs/engine-oniguruma': 3.1.0
-      '@shikijs/types': 3.1.0
+      '@shikijs/engine-oniguruma': 3.2.1
+      '@shikijs/types': 3.2.1
       '@shikijs/vscode-textmate': 10.0.2
 
   '@humanfs/core@0.19.1': {}
@@ -2145,12 +2145,12 @@ snapshots:
       - '@types/node'
     optional: true
 
-  '@shikijs/engine-oniguruma@3.1.0':
+  '@shikijs/engine-oniguruma@3.2.1':
     dependencies:
-      '@shikijs/types': 3.1.0
+      '@shikijs/types': 3.2.1
       '@shikijs/vscode-textmate': 10.0.2
 
-  '@shikijs/types@3.1.0':
+  '@shikijs/types@3.2.1':
     dependencies:
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
@@ -3204,9 +3204,9 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
 
-  typedoc@0.28.0-beta.2(typescript@5.8.2):
+  typedoc@0.28.0(typescript@5.8.2):
     dependencies:
-      '@gerrit0/mini-shiki': 3.1.0
+      '@gerrit0/mini-shiki': 3.2.1
       lunr: 2.3.9
       markdown-it: 14.1.0
       minimatch: 9.0.5

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,10 +35,10 @@ importers:
         version: 6.0.1
       tsup:
         specifier: 8.4.0
-        version: 8.4.0(@microsoft/api-extractor@7.48.0(@types/node@22.2.0))(postcss@8.4.41)(typescript@5.8.2)(yaml@2.6.1)
+        version: 8.4.0(@microsoft/api-extractor@7.48.0(@types/node@22.2.0))(postcss@8.4.41)(typescript@5.8.2)(yaml@2.7.0)
       typedoc:
-        specifier: 0.27.9
-        version: 0.27.9(typescript@5.8.2)
+        specifier: 0.28.0-beta.2
+        version: 0.28.0-beta.2(typescript@5.8.2)
       typescript:
         specifier: 5.8.2
         version: 5.8.2
@@ -408,8 +408,8 @@ packages:
     resolution: {integrity: sha512-JubJ5B2pJ4k4yGxaNLdbjrnk9d/iDz6/q8wOilpIowd6PJPgaxCuHBnBszq7Ce2TyMrywm5r4PnKm6V3iiZF+g==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@gerrit0/mini-shiki@1.24.1':
-    resolution: {integrity: sha512-PNP/Gjv3VqU7z7DjRgO3F9Ok5frTKqtpV+LJW1RzMcr2zpRk0ulhEWnbcNGXzPC7BZyWMIHrkfQX2GZRfxrn6Q==}
+  '@gerrit0/mini-shiki@3.1.0':
+    resolution: {integrity: sha512-ATE2iExp2tOYU1ANeGvxNFyc0slbxQBM6/KCHsAn0JHB7PC3AG/8y3d6Jdz9IVRpE+t9GmpjB5UiZT9EuuJG4w==}
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -603,14 +603,14 @@ packages:
   '@rushstack/ts-command-line@4.23.1':
     resolution: {integrity: sha512-40jTmYoiu/xlIpkkRsVfENtBq4CW3R4azbL0Vmda+fMwHWqss6wwf/Cy/UJmMqIzpfYc2OTnjYP1ZLD3CmyeCA==}
 
-  '@shikijs/engine-oniguruma@1.24.0':
-    resolution: {integrity: sha512-Eua0qNOL73Y82lGA4GF5P+G2+VXX9XnuUxkiUuwcxQPH4wom+tE39kZpBFXfUuwNYxHSkrSxpB1p4kyRW0moSg==}
+  '@shikijs/engine-oniguruma@3.1.0':
+    resolution: {integrity: sha512-reRgy8VzDPdiDocuGDD60Rk/jLxgcgy+6H4n6jYLeN2Yw5ikasRjQQx8ERXtDM35yg2v/d6KolDBcK8hYYhcmw==}
 
-  '@shikijs/types@1.24.0':
-    resolution: {integrity: sha512-aptbEuq1Pk88DMlCe+FzXNnBZ17LCiLIGWAeCWhoFDzia5Q5Krx3DgnULLiouSdd6+LUM39XwXGppqYE0Ghtug==}
+  '@shikijs/types@3.1.0':
+    resolution: {integrity: sha512-F8e7Fy4ihtcNpJG572BZZC1ErYrBrzJ5Cbc9Zi3REgWry43gIvjJ9lFAoUnuy7Bvy4IFz7grUSxL5edfrrjFEA==}
 
-  '@shikijs/vscode-textmate@9.3.0':
-    resolution: {integrity: sha512-jn7/7ky30idSkd/O5yDBfAnVt+JJpepofP/POZ1iMOxK59cOfqIgg/Dj0eFsjOTMw+4ycJN0uhZH/Eb0bs/EUA==}
+  '@shikijs/vscode-textmate@10.0.2':
+    resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
 
   '@types/argparse@1.0.38':
     resolution: {integrity: sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==}
@@ -1581,9 +1581,9 @@ packages:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
 
-  typedoc@0.27.9:
-    resolution: {integrity: sha512-/z585740YHURLl9DN2jCWe6OW7zKYm6VoQ93H0sxZ1cwHQEQrUn5BJrEnkWhfzUdyO+BLGjnKUZ9iz9hKloFDw==}
-    engines: {node: '>= 18'}
+  typedoc@0.28.0-beta.2:
+    resolution: {integrity: sha512-+7YrRafvYClYuQqhWUvUkUAB/eD7Jh1gls/PVeCOInz3MeOYnl8H76EnnMp7kiXeNV35GwP3foVbNCaxyO8OFg==}
+    engines: {node: '>= 18', pnpm: '>= 10'}
     hasBin: true
     peerDependencies:
       typescript: 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x
@@ -1721,8 +1721,8 @@ packages:
   yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
 
-  yaml@2.6.1:
-    resolution: {integrity: sha512-7r0XPzioN/Q9kXBro/XPnA6kznR73DHq+GXh5ON7ZozRO6aMjbmiBuKste2wslTFkC5d1dw0GooOCepZXJ2SAg==}
+  yaml@2.7.0:
+    resolution: {integrity: sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==}
     engines: {node: '>= 14'}
     hasBin: true
 
@@ -1949,11 +1949,11 @@ snapshots:
       '@eslint/core': 0.12.0
       levn: 0.4.1
 
-  '@gerrit0/mini-shiki@1.24.1':
+  '@gerrit0/mini-shiki@3.1.0':
     dependencies:
-      '@shikijs/engine-oniguruma': 1.24.0
-      '@shikijs/types': 1.24.0
-      '@shikijs/vscode-textmate': 9.3.0
+      '@shikijs/engine-oniguruma': 3.1.0
+      '@shikijs/types': 3.1.0
+      '@shikijs/vscode-textmate': 10.0.2
 
   '@humanfs/core@0.19.1': {}
 
@@ -2145,17 +2145,17 @@ snapshots:
       - '@types/node'
     optional: true
 
-  '@shikijs/engine-oniguruma@1.24.0':
+  '@shikijs/engine-oniguruma@3.1.0':
     dependencies:
-      '@shikijs/types': 1.24.0
-      '@shikijs/vscode-textmate': 9.3.0
+      '@shikijs/types': 3.1.0
+      '@shikijs/vscode-textmate': 10.0.2
 
-  '@shikijs/types@1.24.0':
+  '@shikijs/types@3.1.0':
     dependencies:
-      '@shikijs/vscode-textmate': 9.3.0
+      '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
 
-  '@shikijs/vscode-textmate@9.3.0': {}
+  '@shikijs/vscode-textmate@10.0.2': {}
 
   '@types/argparse@1.0.38':
     optional: true
@@ -2968,12 +2968,12 @@ snapshots:
 
   pirates@4.0.6: {}
 
-  postcss-load-config@6.0.1(postcss@8.4.41)(yaml@2.6.1):
+  postcss-load-config@6.0.1(postcss@8.4.41)(yaml@2.7.0):
     dependencies:
       lilconfig: 3.1.2
     optionalDependencies:
       postcss: 8.4.41
-      yaml: 2.6.1
+      yaml: 2.7.0
 
   postcss@8.4.41:
     dependencies:
@@ -3172,7 +3172,7 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  tsup@8.4.0(@microsoft/api-extractor@7.48.0(@types/node@22.2.0))(postcss@8.4.41)(typescript@5.8.2)(yaml@2.6.1):
+  tsup@8.4.0(@microsoft/api-extractor@7.48.0(@types/node@22.2.0))(postcss@8.4.41)(typescript@5.8.2)(yaml@2.7.0):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.25.0)
       cac: 6.7.14
@@ -3182,7 +3182,7 @@ snapshots:
       esbuild: 0.25.0
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(postcss@8.4.41)(yaml@2.6.1)
+      postcss-load-config: 6.0.1(postcss@8.4.41)(yaml@2.7.0)
       resolve-from: 5.0.0
       rollup: 4.34.9
       source-map: 0.8.0-beta.0
@@ -3204,14 +3204,14 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
 
-  typedoc@0.27.9(typescript@5.8.2):
+  typedoc@0.28.0-beta.2(typescript@5.8.2):
     dependencies:
-      '@gerrit0/mini-shiki': 1.24.1
+      '@gerrit0/mini-shiki': 3.1.0
       lunr: 2.3.9
       markdown-it: 14.1.0
       minimatch: 9.0.5
       typescript: 5.8.2
-      yaml: 2.6.1
+      yaml: 2.7.0
 
   typescript-eslint@8.26.0(eslint@9.22.0)(typescript@5.8.2):
     dependencies:
@@ -3340,6 +3340,6 @@ snapshots:
   yallist@4.0.0:
     optional: true
 
-  yaml@2.6.1: {}
+  yaml@2.7.0: {}
 
   yocto-queue@0.1.0: {}

--- a/typedoc.json
+++ b/typedoc.json
@@ -3,6 +3,7 @@
   "entryPoints": ["./src/v20170710/index.ts", "./src/index.ts"],
   "out": "docs",
   "plugin": ["./typedoc/plugin.js"],
+  "router": "cloudflare",
   "sourceLinkTemplate": "https://github.com/bachman-dev/wanikani-api-types/blob/{gitRevision}/{path}#L{line}",
   "cleanOutputDir": true,
   "includeVersion": true,

--- a/typedoc/plugin.js
+++ b/typedoc/plugin.js
@@ -3,7 +3,6 @@ import { Application, Converter, KindRouter, ReflectionKind } from "typedoc";
 
 class CloudflareRouter extends KindRouter {
   /**
-   *
    * @param {Application} app
    */
   constructor(app) {

--- a/typedoc/plugin.js
+++ b/typedoc/plugin.js
@@ -1,11 +1,38 @@
 // @ts-check
-import { Converter, ReflectionKind } from "typedoc";
-/** @typedef { import("typedoc").Application } Application */
+import { Application, Converter, KindRouter, ReflectionKind } from "typedoc";
+
+class CloudflareRouter extends KindRouter {
+  /** @type Map<ReflectionKind, string> */
+  directories = new Map([
+    [ReflectionKind.Class, "classes"],
+    [ReflectionKind.Interface, "interfaces"],
+    [ReflectionKind.Enum, "enums"],
+    [ReflectionKind.Namespace, "modules"],
+    [ReflectionKind.Module, "modules"],
+    [ReflectionKind.TypeAlias, "types"],
+    [ReflectionKind.Function, "methods"],
+    [ReflectionKind.Variable, "variables"],
+    [ReflectionKind.Document, "documents"],
+  ]);
+
+  /**
+   *
+   * @param {Application} app
+   */
+  constructor(app) {
+    super(app);
+    this.application.logger.info("Using Cloudflare Router");
+  }
+}
 
 /**
  * @param {Application} app
  */
 export function load(app) {
+  app.on(Application.EVENT_BOOTSTRAP_END, () => {
+    app.renderer.defineRouter("cloudflare", CloudflareRouter);
+  });
+
   app.converter.on(Converter.EVENT_CREATE_DECLARATION, (context, refl) => {
     // Remove any Valibot schemas from the documentation
     if (

--- a/typedoc/plugin.js
+++ b/typedoc/plugin.js
@@ -2,25 +2,13 @@
 import { Application, Converter, KindRouter, ReflectionKind } from "typedoc";
 
 class CloudflareRouter extends KindRouter {
-  /** @type Map<ReflectionKind, string> */
-  directories = new Map([
-    [ReflectionKind.Class, "classes"],
-    [ReflectionKind.Interface, "interfaces"],
-    [ReflectionKind.Enum, "enums"],
-    [ReflectionKind.Namespace, "modules"],
-    [ReflectionKind.Module, "modules"],
-    [ReflectionKind.TypeAlias, "types"],
-    [ReflectionKind.Function, "methods"],
-    [ReflectionKind.Variable, "variables"],
-    [ReflectionKind.Document, "documents"],
-  ]);
-
   /**
    *
    * @param {Application} app
    */
   constructor(app) {
     super(app);
+    this.directories.set(ReflectionKind.Function, "methods");
     this.application.logger.info("Using Cloudflare Router");
   }
 }


### PR DESCRIPTION
# Description

This PR adds a typedoc router to the plugin, allowing us to override the `functions` folder generated by typedoc to `methods` like we've done in the past, but in a much cleaner fashion thanks to typedoc's new router feature. This will be backported to the main branch so that we can move back to Cloudflare Pages.

This PR will be merged when typedoc 0.28 is out of beta.

# Related Issue(s) / Pull Request(s)

None

# Nature of Pull Request

This Pull Request:

- [ ] Adds/Updates Type(s) described in the WaniKani API Docs
- [ ] Adds/Updates Type(s) provided by the `wanikani-api-types` package itself
- [ ] Adds/Updates constants or other variables provided by the package
- [ ] Adds/Updates Helper Functions/Type Guards provided by the package
- [x] Updates Documentation
- [x] Updates Project and/or Community Health files (e.g. README, GitHub Actions, etc.)

Its changes constitutes a:

- [x] Non-code change (i.e. no version bump)
- [ ] Bug Fix or Other Small Changes (i.e. patch version bump)
- [ ] Forward-compatible Enhancement (i.e. minor version bump)
- [ ] ⚠️ BREAKING CHANGE regarding TypeScript, Package, and/or WaniKani API version(s) (i.e. MAJOR version bump)

# Additional Info

None

# Contribution Terms

I understand that by submitting this Pull Request:

- I agree to the terms outlined in the [Contribution Guidelines](https://github.com/bachman-dev/wanikani-api-types/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/bachman-dev/wanikani-api-types/blob/main/CODE_OF_CONDUCT.md)
- My code will be licensed for use in this repository per its [LICENSE](https://github.com/bachman-dev/wanikani-api-types/blob/main/LICENSE), and that I have the right to license this code -- per GitHub's [Terms of Service](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service#6-contributions-under-repository-license)
