### PR TITLE
Chore: Remove Unreleased datableString Method

### DIFF
--- a/src/v20170710/base.ts
+++ b/src/v20170710/base.ts
@@ -38,17 +38,6 @@ export type DatableString = v.Brand<"DatableString"> & string;
 export const DatableString = v.pipe(v.string(), v.trim(), v.isoTimestamp(), v.brand("DatableString"));
 
 /**
- * Validates that a string is a well-formatted ISO-8601 dat string.
- *
- * @param value The string you wish to parse and validate
- * @returns A string that can be used for date filtering in the WaniKani API
- * @category Base
- */
-export function datableString(value: string): DatableString {
-  return v.parse(DatableString, value);
-}
-
-/**
  * A type guard that checks if the given value matches the type predicate.
  *
  * @category Base

--- a/tests/v20170710/base.test.ts
+++ b/tests/v20170710/base.test.ts
@@ -13,17 +13,14 @@ describe("ApiRevision", () => {
 describe("DatableString", () => {
   testFor("Valid UTC timestamp string", ({ dateTimeUtcString }) => {
     expect(() => v.assert(WK.DatableString, dateTimeUtcString)).not.toThrow();
-    expect(() => WK.datableString(dateTimeUtcString)).not.toThrow();
     expect(WK.isDatableString(dateTimeUtcString)).toBe(true);
   });
   testFor("Valid offset timestamp string", ({ dateTimeOffsetString }) => {
     expect(() => v.assert(WK.DatableString, dateTimeOffsetString)).not.toThrow();
-    expect(() => WK.datableString(dateTimeOffsetString)).not.toThrow();
     expect(WK.isDatableString(dateTimeOffsetString)).toBe(true);
   });
   testFor("String created from Date.toISOString", ({ dateIsoString }) => {
     expect(() => v.assert(WK.DatableString, dateIsoString)).not.toThrow();
-    expect(() => WK.datableString(dateIsoString)).not.toThrow();
     expect(WK.isDatableString(dateIsoString)).toBe(true);
   });
 });


### PR DESCRIPTION
# Description

This PR removes the unreleased `datableString` method from the library. We're opting for `DatableString` to continue being primarily a type that is returned from the WaniKani API, and potentially reused from there, rather than something a user would intentionally create vs creating a `Date` object, e.g. when stringifying `CollectionParameters`.

# Related Issue(s) / Pull Request(s)

None

# Nature of Pull Request

This Pull Request:

- [ ] Adds/Updates Type(s) described in the WaniKani API Docs
- [x] Adds/Updates Type(s) provided by the `wanikani-api-types` package itself
- [ ] Adds/Updates constants or other variables provided by the package
- [x] Adds/Updates Helper Functions/Type Guards provided by the package
- [ ] Updates Documentation
- [ ] Updates Project and/or Community Health files (e.g. README, GitHub Actions, etc.)

Its changes constitutes a:

- [ ] Non-code change (i.e. no version bump)
- [ ] Bug Fix or Other Small Changes (i.e. patch version bump)
- [x] Forward-compatible Enhancement (i.e. minor version bump)
- [ ] ⚠️ BREAKING CHANGE regarding TypeScript, Package, and/or WaniKani API version(s) (i.e. MAJOR version bump)

# Additional Info

None

# Contribution Terms

I understand that by submitting this Pull Request:

- I agree to the terms outlined in the [Contribution Guidelines](https://github.com/bachman-dev/wanikani-api-types/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/bachman-dev/wanikani-api-types/blob/main/CODE_OF_CONDUCT.md)
- My code will be licensed for use in this repository per its [LICENSE](https://github.com/bachman-dev/wanikani-api-types/blob/main/LICENSE), and that I have the right to license this code -- per GitHub's [Terms of Service](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service#6-contributions-under-repository-license)
