### PR TITLE
Chore: Rename Package (main)

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -30,8 +30,8 @@ const WANIKANI_API_TOKEN = env["WANIKANI_API_TOKEN"];
 Maybe you want a bar/line graph of your review workload for the day...
 
 ```typescript
-import type { WKError, WKSummary } from "@bachmacintosh/wanikani-api-types/dist/v20170710";
-import { WKRequestFactory, WK_API_REVISION } from "@bachmacintosh/wanikani-api-types/dist/v20170710";
+import type { WKError, WKSummary } from "@bachman-dev/wanikani-api-types/dist/v20170710";
+import { WKRequestFactory, WK_API_REVISION } from "@bachman-dev/wanikani-api-types/dist/v20170710";
 
 interface WaniKaniReviewForecast {
   date: Date;
@@ -77,8 +77,8 @@ import type {
   WKSubjectCollection,
   WKSubjectData,
   WKSubjectParameters,
-} from "@bachmacintosh/wanikani-api-types/dist/v20170710";
-import { WKRequestFactory, WK_API_REVISION, isWKLevel } from "@bachmacintosh/wanikani-api-types/dist/v20170710";
+} from "@bachman-dev/wanikani-api-types/dist/v20170710";
+import { WKRequestFactory, WK_API_REVISION, isWKLevel } from "@bachman-dev/wanikani-api-types/dist/v20170710";
 
 async function getSubjects(level?: number): Promise<WKSubjectData[]> {
   if (typeof level !== "undefined" && !isWKLevel(level)) {
@@ -134,8 +134,8 @@ import type {
   WKSubjectData,
   WKSubjectParameters,
   WKUser,
-} from "@bachmacintosh/wanikani-api-types/dist/v20170710";
-import { WKRequestFactory, WK_API_REVISION } from "@bachmacintosh/wanikani-api-types/dist/v20170710";
+} from "@bachman-dev/wanikani-api-types/dist/v20170710";
+import { WKRequestFactory, WK_API_REVISION } from "@bachman-dev/wanikani-api-types/dist/v20170710";
 
 interface WaniKaniLesson {
   subject: WKSubjectData;
@@ -263,8 +263,8 @@ import type {
   WKAssignmentPayload,
   WKDatableString,
   WKError,
-} from "@bachmacintosh/wanikani-api-types/dist/v20170710";
-import { WKRequestFactory, WK_API_REVISION, isWKDatableString } from "@bachmacintosh/wanikani-api-types/dist/v20170710";
+} from "@bachman-dev/wanikani-api-types/dist/v20170710";
+import { WKRequestFactory, WK_API_REVISION, isWKDatableString } from "@bachman-dev/wanikani-api-types/dist/v20170710";
 
 async function startAssignment(id: number, started_at?: WKDatableString | Date): Promise<WKAssignment> {
   let payload: WKAssignmentPayload = {};
@@ -306,8 +306,8 @@ import type {
   WKDatableString,
   WKError,
   WKReviewPayload,
-} from "@bachmacintosh/wanikani-api-types/dist/v20170710";
-import { WKRequestFactory, WK_API_REVISION, isWKDatableString } from "@bachmacintosh/wanikani-api-types/dist/v20170710";
+} from "@bachman-dev/wanikani-api-types/dist/v20170710";
+import { WKRequestFactory, WK_API_REVISION, isWKDatableString } from "@bachman-dev/wanikani-api-types/dist/v20170710";
 
 async function createReview(
   id: number,

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# @bachmacintosh/wanikani-api-types
+# @bachman-dev/wanikani-api-types
 
 [![Tests (Main)](https://github.com/bachman-dev/wanikani-api-types/actions/workflows/push.yml/badge.svg)](https://github.com/bachman-dev/wanikani-api-types/actions/workflows/push.yml)
 [![codecov](https://codecov.io/gh/bachman-dev/wanikani-api-types/branch/main/graph/badge.svg?token=CCVBE1UM9M)](https://codecov.io/gh/bachman-dev/wanikani-api-types)
@@ -33,15 +33,15 @@ A new Major Version x includes backwards-incompatible changes such as removing p
 Run the following command pertaining to your package manager:
 
 ```shell
-npm install @bachmacintosh/wanikani-api-types
+npm install @bachman-dev/wanikani-api-types
 ```
 
 ```shell
-yarn add @bachmacintosh/wanikani-api-types
+yarn add @bachman-dev/wanikani-api-types
 ```
 
 ```shell
-pnpm install @bachmacintosh/wanikani-api-types
+pnpm add @bachman-dev/wanikani-api-types
 ```
 
 Then, import using one of two methods.
@@ -51,8 +51,8 @@ Then, import using one of two methods.
 The module you import from matches a [WaniKani API Revision](https://docs.api.wanikani.com/20170710/#revisions-aka-versioning); you shouldn't expect any breaking changes from the package.
 
 ```typescript
-import type { WKAssignmentParameters, WKDatableString } from "@bachmacintosh/wanikani-api-types/dist/v20170710";
-import { stringifyParameters } from "@bachmacintosh/wanikani-api-types/dist/v20170710";
+import type { WKAssignmentParameters, WKDatableString } from "@bachman-dev/wanikani-api-types/dist/v20170710";
+import { stringifyParameters } from "@bachman-dev/wanikani-api-types/dist/v20170710";
 ```
 
 #### Latest API Revision (Not Recommended)
@@ -60,8 +60,8 @@ import { stringifyParameters } from "@bachmacintosh/wanikani-api-types/dist/v201
 Importing from the index module will always provide types, methods, etc. for use with the latest and greatest API Revision.
 
 ```typescript
-import type { WKAssignmentParameters, WKDatableString } from "@bachmacintosh/wanikani-api-types";
-import { stringifyParameters } from "@bachmacintosh/wanikani-api-types";
+import type { WKAssignmentParameters, WKDatableString } from "@bachman-dev/wanikani-api-types";
+import { stringifyParameters } from "@bachman-dev/wanikani-api-types";
 ```
 
 </details>
@@ -80,11 +80,8 @@ Deno version 1.28 and up can import the library using an [npm specifier](https:/
 The module you import from matches a [WaniKani API Revision](https://docs.api.wanikani.com/20170710/#revisions-aka-versioning); you shouldn't expect any breaking changes from the package.
 
 ```typescript
-import type {
-  WKAssignmentParameters,
-  WKDatableString,
-} from "npm:@bachmacintosh/wanikani-api-types@x.y.z/dist/v20170710";
-import { stringifyParameters } from "npm:@bachmacintosh/wanikani-api-types@x.y.z/dist/v20170710";
+import type { WKAssignmentParameters, WKDatableString } from "npm:@bachman-dev/wanikani-api-types@x.y.z/dist/v20170710";
+import { stringifyParameters } from "npm:@bachman-dev/wanikani-api-types@x.y.z/dist/v20170710";
 ```
 
 #### Latest API Revision (Not Recommended)
@@ -92,8 +89,8 @@ import { stringifyParameters } from "npm:@bachmacintosh/wanikani-api-types@x.y.z
 Importing from the index module will always provide types, methods, etc. for use with the latest and greatest API Revision.
 
 ```typescript
-import type { WKAssignmentParameters, WKDatableString } from "npm:@bachmacintosh/wanikani-api-types@x.y.z";
-import { stringifyParameters } from "npm:@bachmacintosh/wanikani-api-types@x.y.z";
+import type { WKAssignmentParameters, WKDatableString } from "npm:@bachman-dev/wanikani-api-types@x.y.z";
+import { stringifyParameters } from "npm:@bachman-dev/wanikani-api-types@x.y.z";
 ```
 
 </details>
@@ -116,8 +113,8 @@ The module you import from matches a [WaniKani API Revision](https://docs.api.wa
 import type {
   WKAssignmentParameters,
   WKDatableString,
-} from "https://esm.sh/@bachmacintosh/wanikani-api-types@x.y.z/dist/v20170710.js";
-import { stringifyParameters } from "https://esm.sh/@bachmacintosh/wanikani-api-types@x.y.z/dist/v20170710.js";
+} from "https://esm.sh/@bachman-dev/wanikani-api-types@x.y.z/dist/v20170710.js";
+import { stringifyParameters } from "https://esm.sh/@bachman-dev/wanikani-api-types@x.y.z/dist/v20170710.js";
 ```
 
 #### Latest API Revision (Not Recommended)
@@ -125,8 +122,8 @@ import { stringifyParameters } from "https://esm.sh/@bachmacintosh/wanikani-api-
 Importing from the index module will always provide types, methods, etc. for use with the latest and greatest API Revision.
 
 ```typescript
-import type { WKAssignmentParameters, WKDatableString } from "https://esm.sh/@bachmacintosh/wanikani-api-types@x.y.z";
-import { stringifyParameters } from "https://esm.sh/@bachmacintosh/wanikani-api-types@x.y.z";
+import type { WKAssignmentParameters, WKDatableString } from "https://esm.sh/@bachman-dev/wanikani-api-types@x.y.z";
+import { stringifyParameters } from "https://esm.sh/@bachman-dev/wanikani-api-types@x.y.z";
 ```
 
 </details>

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@bachmacintosh/wanikani-api-types",
+  "name": "@bachman-dev/wanikani-api-types",
   "version": "1.8.0",
   "description": "Regularly updated type definitions for the WaniKani API",
   "keywords": [


### PR DESCRIPTION
# Description

This PR renames the package to `@bachman-dev/wanikani-api-types`, to be consistent with the organization it's under on GitHub. The old package at `@bachmacintosh/wanikani-api-types` will be marked deprecated, with instructions to install this version instead. There will be no version bump.

# Related Issue(s) / Pull Request(s)

None

# Nature of Pull Request

This Pull Request:

- [ ] Adds/Updates Type(s) described in the WaniKani API Docs
- [ ] Adds/Updates Type(s) provided by the `wanikani-api-types` package itself
- [ ] Adds/Updates constants or other variables provided by the package
- [ ] Adds/Updates Helper Functions/Type Guards provided by the package
- [ ] Updates Documentation
- [x] Updates Project and/or Community Health files (e.g. README, GitHub Actions, etc.)

Its changes constitutes a:

- [x] Non-code change (i.e. no version bump)
- [ ] Bug Fix or Other Small Changes (i.e. patch version bump)
- [ ] Forward-compatible Enhancement (i.e. minor version bump)
- [ ] ⚠️ BREAKING CHANGE regarding TypeScript, Package, and/or WaniKani API version(s) (i.e. MAJOR version bump)

# Additional Info

None

# Contribution Terms

I understand that by submitting this Pull Request:

- I agree to the terms outlined in the [Contribution Guidelines](https://github.com/bachman-dev/wanikani-api-types/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/bachman-dev/wanikani-api-types/blob/main/CODE_OF_CONDUCT.md)
- My code will be licensed for use in this repository per its [LICENSE](https://github.com/bachman-dev/wanikani-api-types/blob/main/LICENSE), and that I have the right to license this code -- per GitHub's [Terms of Service](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service#6-contributions-under-repository-license)
