### PR TITLE
Schema: Add Integer Validation to IDs

### DIFF
--- a/src/v20170710/assignments.ts
+++ b/src/v20170710/assignments.ts
@@ -1,6 +1,6 @@
 import * as m from "./lang/index.js";
 import * as v from "valibot";
-import { BaseCollection, BaseResource, CollectionParameters, DatableString, Level } from "./base.js";
+import { BaseCollection, BaseResource, CollectionParameters, DatableString, Integer, Level } from "./base.js";
 import { SubjectTuple, SubjectType } from "./subjects.js";
 import { SpacedRepetitionSystemStageNumber } from "./spaced-repetition-systems.js";
 
@@ -223,7 +223,7 @@ export interface AssignmentParameters extends CollectionParameters {
   /**
    * Only assignments where `data.subject_id` matches one of the array values are returned.
    */
-  subject_ids?: number[];
+  subject_ids?: Integer[];
 
   /**
    * Only assignments where `data.subject_type` matches one of the array values are returned.
@@ -250,7 +250,7 @@ export const AssignmentParameters = v.object(
       levels: v.optional(v.array(Level)),
       srs_stages: v.optional(v.array(SpacedRepetitionSystemStageNumber)),
       started: v.optional(v.boolean()),
-      subject_ids: v.optional(v.array(v.number())),
+      subject_ids: v.optional(v.array(Integer)),
       subject_types: v.optional(SubjectTuple),
       unlocked: v.optional(v.boolean()),
     }),

--- a/src/v20170710/assignments.ts
+++ b/src/v20170710/assignments.ts
@@ -1,6 +1,6 @@
 import * as m from "./lang/index.js";
 import * as v from "valibot";
-import { BaseCollection, BaseResource, CollectionParameters, DatableString, Integer, Level } from "./base.js";
+import { BaseCollection, BaseResource, CollectionParameters, DatableString, Level, SafeInteger } from "./base.js";
 import { SubjectTuple, SubjectType } from "./subjects.js";
 import { SpacedRepetitionSystemStageNumber } from "./spaced-repetition-systems.js";
 
@@ -223,7 +223,7 @@ export interface AssignmentParameters extends CollectionParameters {
   /**
    * Only assignments where `data.subject_id` matches one of the array values are returned.
    */
-  subject_ids?: Integer[];
+  subject_ids?: SafeInteger[];
 
   /**
    * Only assignments where `data.subject_type` matches one of the array values are returned.
@@ -250,7 +250,7 @@ export const AssignmentParameters = v.object(
       levels: v.optional(v.array(Level)),
       srs_stages: v.optional(v.array(SpacedRepetitionSystemStageNumber)),
       started: v.optional(v.boolean()),
-      subject_ids: v.optional(v.array(Integer)),
+      subject_ids: v.optional(v.array(SafeInteger)),
       subject_types: v.optional(SubjectTuple),
       unlocked: v.optional(v.boolean()),
     }),

--- a/src/v20170710/base.ts
+++ b/src/v20170710/base.ts
@@ -31,12 +31,12 @@ export function isApiRevision(value: unknown): value is ApiRevision {
 }
 
 /**
- * Items with this type will have their number validated as an integer (i.e. whole number).
+ * Items with this type will have their number validated as a safe integer >= 0.
  *
  * @category Base
  */
-export type Integer = number & {};
-export const Integer = v.pipe(v.number(), v.integer());
+export type SafeInteger = number & {};
+export const SafeInteger = v.pipe(v.number(), v.safeInteger(), v.minValue(0));
 
 /**
  * A `string` sent to/returned from the WaniKani API that can be converted into a JavaScript `Date` object.
@@ -77,7 +77,7 @@ export const MAX_LEVEL = 60;
  * @category Base
  */
 export type Level = number & {};
-export const Level = v.pipe(Integer, v.minValue(MIN_LEVEL), v.maxValue(MAX_LEVEL));
+export const Level = v.pipe(SafeInteger, v.minValue(MIN_LEVEL), v.maxValue(MAX_LEVEL));
 
 /**
  * A type guard that checks if the given value matches the type predicate.
@@ -191,21 +191,21 @@ export interface CollectionParameters {
   /**
    * Only resources where `data.id` matches one of the array values are returned.
    */
-  ids?: Integer[];
+  ids?: SafeInteger[];
 
   /**
    * Get a collection's next page containing `pages.per_page` resources after the given ID.
    *
    * This will take precedence over `page_before_id` if both are specified.
    */
-  page_after_id?: Integer;
+  page_after_id?: SafeInteger;
 
   /**
    * Get a collection's previous page containing `pages.per_page` resources before the given ID.
    *
    * The `page_after_id` parameter takes precedence over this if it is specified alongside this parameter.
    */
-  page_before_id?: Integer;
+  page_before_id?: SafeInteger;
 
   /**
    * Only resources updated after this time are returned.
@@ -213,9 +213,9 @@ export interface CollectionParameters {
   updated_after?: DatableString | Date;
 }
 export const CollectionParameters = v.object({
-  ids: v.optional(v.array(Integer)),
-  page_after_id: v.optional(Integer),
-  page_before_id: v.optional(Integer),
+  ids: v.optional(v.array(SafeInteger)),
+  page_after_id: v.optional(SafeInteger),
+  page_before_id: v.optional(SafeInteger),
   updated_after: v.optional(v.union([DatableString, v.date()], m.dateUnion)),
 });
 

--- a/src/v20170710/base.ts
+++ b/src/v20170710/base.ts
@@ -31,6 +31,14 @@ export function isApiRevision(value: unknown): value is ApiRevision {
 }
 
 /**
+ * Items with this type will have their number validated as an integer (i.e. whole number).
+ *
+ * @category Base
+ */
+export type Integer = number & {};
+export const Integer = v.pipe(v.number(), v.integer());
+
+/**
  * A `string` sent to/returned from the WaniKani API that can be converted into a JavaScript `Date` object.
  *
  * @category Base
@@ -69,7 +77,7 @@ export const MAX_LEVEL = 60;
  * @category Base
  */
 export type Level = number & {};
-export const Level = v.pipe(v.number(), v.integer(), v.minValue(MIN_LEVEL), v.maxValue(MAX_LEVEL));
+export const Level = v.pipe(Integer, v.minValue(MIN_LEVEL), v.maxValue(MAX_LEVEL));
 
 /**
  * A type guard that checks if the given value matches the type predicate.
@@ -183,21 +191,21 @@ export interface CollectionParameters {
   /**
    * Only resources where `data.id` matches one of the array values are returned.
    */
-  ids?: number[];
+  ids?: Integer[];
 
   /**
    * Get a collection's next page containing `pages.per_page` resources after the given ID.
    *
    * This will take precedence over `page_before_id` if both are specified.
    */
-  page_after_id?: number;
+  page_after_id?: Integer;
 
   /**
    * Get a collection's previous page containing `pages.per_page` resources before the given ID.
    *
    * The `page_after_id` parameter takes precedence over this if it is specified alongside this parameter.
    */
-  page_before_id?: number;
+  page_before_id?: Integer;
 
   /**
    * Only resources updated after this time are returned.
@@ -205,9 +213,9 @@ export interface CollectionParameters {
   updated_after?: DatableString | Date;
 }
 export const CollectionParameters = v.object({
-  ids: v.optional(v.array(v.number())),
-  page_after_id: v.optional(v.number()),
-  page_before_id: v.optional(v.number()),
+  ids: v.optional(v.array(Integer)),
+  page_after_id: v.optional(Integer),
+  page_before_id: v.optional(Integer),
   updated_after: v.optional(v.union([DatableString, v.date()], m.dateUnion)),
 });
 

--- a/src/v20170710/lang/review-payload-union.ts
+++ b/src/v20170710/lang/review-payload-union.ts
@@ -1,7 +1,7 @@
 import type * as v from "valibot";
 import { getLocale } from "./_internal.js";
 
-type Message = v.ErrorMessage<v.UnionIssue<v.NeverIssue | v.NumberIssue | v.ObjectIssue>>;
+type Message = v.ErrorMessage<v.UnionIssue<v.IntegerIssue<number> | v.NeverIssue | v.NumberIssue | v.ObjectIssue>>;
 
 const en: Message = "Review Payload must have one and only one of either an assignment_id or subject_id number";
 

--- a/src/v20170710/lang/review-payload-union.ts
+++ b/src/v20170710/lang/review-payload-union.ts
@@ -1,9 +1,12 @@
 import type * as v from "valibot";
 import { getLocale } from "./_internal.js";
 
-type Message = v.ErrorMessage<v.UnionIssue<v.IntegerIssue<number> | v.NeverIssue | v.NumberIssue | v.ObjectIssue>>;
+type Message = v.ErrorMessage<
+  v.UnionIssue<v.MinValueIssue<number, 0> | v.NeverIssue | v.NumberIssue | v.ObjectIssue | v.SafeIntegerIssue<number>>
+>;
 
-const en: Message = "Review Payload must have one and only one of either an assignment_id or subject_id number";
+const en: Message =
+  "Review Payload must have one and only one of either an assignment_id or subject_id positive integer";
 
 // @__NO_SIDE_EFFECTS__
 export const reviewPayloadUnion: Message = (issue) => {

--- a/src/v20170710/requests.ts
+++ b/src/v20170710/requests.ts
@@ -1,5 +1,5 @@
 import * as v from "valibot";
-import { ApiRevision, Integer, stringifyParameters } from "./base.js";
+import { ApiRevision, SafeInteger, stringifyParameters } from "./base.js";
 import { AssignmentParameters, AssignmentPayload } from "./assignments.js";
 import { ReviewParameters, ReviewPayload } from "./reviews.js";
 import { StudyMaterialCreatePayload, StudyMaterialParameters, StudyMaterialUpdatePayload } from "./study-materials.js";
@@ -47,7 +47,7 @@ export class ApiRequestFactory {
      * @throws A `TypeError` if trying to set type-checked request headers.
      * @throws A {@link valibot!ValiError} if ID or parameters are invalid.
      */
-    get: (idOrParams?: AssignmentParameters | Integer, options?: ApiRequestOptions): ApiRequest => {
+    get: (idOrParams?: AssignmentParameters | SafeInteger, options?: ApiRequestOptions): ApiRequest => {
       const headers = { ...this._getHeaders };
       if (typeof options?.customHeaders !== "undefined") {
         for (const [key, value] of Object.entries(options.customHeaders)) {
@@ -62,7 +62,7 @@ export class ApiRequestFactory {
         url: `${this.baseUrl}/assignments`,
       };
       if (typeof idOrParams === "number") {
-        v.assert(Integer, idOrParams);
+        v.assert(SafeInteger, idOrParams);
         request.url += `/${idOrParams}`;
       } else if (typeof idOrParams !== "undefined") {
         v.assert(AssignmentParameters, idOrParams);
@@ -80,8 +80,8 @@ export class ApiRequestFactory {
      * @throws A `TypeError` if trying to set type-checked request headers.
      * @throws A {@link valibot!ValiError} if ID or payload is invalid.
      */
-    start: (assignmentId: Integer, payload: AssignmentPayload, options?: ApiRequestOptions): ApiRequest => {
-      v.assert(Integer, assignmentId);
+    start: (assignmentId: SafeInteger, payload: AssignmentPayload, options?: ApiRequestOptions): ApiRequest => {
+      v.assert(SafeInteger, assignmentId);
       v.assert(AssignmentPayload, payload);
       const headers = { ...this._postPutHeaders };
       if (typeof options?.customHeaders !== "undefined") {
@@ -116,7 +116,7 @@ export class ApiRequestFactory {
      * @throws A `TypeError` if trying to set type-checked request headers.
      * @throws A {@link valibot!ValiError} if ID or parameters are invalid.
      */
-    get: (idOrParams?: Integer | LevelProgressionParameters, options?: ApiRequestOptions): ApiRequest => {
+    get: (idOrParams?: LevelProgressionParameters | SafeInteger, options?: ApiRequestOptions): ApiRequest => {
       const headers = { ...this._getHeaders };
       if (typeof options?.customHeaders !== "undefined") {
         for (const [key, value] of Object.entries(options.customHeaders)) {
@@ -131,7 +131,7 @@ export class ApiRequestFactory {
         url: `${this.baseUrl}/level_progressions`,
       };
       if (typeof idOrParams === "number") {
-        v.assert(Integer, idOrParams);
+        v.assert(SafeInteger, idOrParams);
         request.url += `/${idOrParams}`;
       } else if (typeof idOrParams !== "undefined") {
         v.assert(LevelProgressionParameters, idOrParams);
@@ -153,7 +153,7 @@ export class ApiRequestFactory {
      * @throws A `TypeError` if trying to set type-checked request headers.
      * @throws A {@link valibot!ValiError} if ID or parameters are invalid.
      */
-    get: (idOrParams?: Integer | ResetParameters, options?: ApiRequestOptions): ApiRequest => {
+    get: (idOrParams?: ResetParameters | SafeInteger, options?: ApiRequestOptions): ApiRequest => {
       const headers = { ...this._getHeaders };
       if (typeof options?.customHeaders !== "undefined") {
         for (const [key, value] of Object.entries(options.customHeaders)) {
@@ -168,7 +168,7 @@ export class ApiRequestFactory {
         url: `${this.baseUrl}/resets`,
       };
       if (typeof idOrParams === "number") {
-        v.assert(Integer, idOrParams);
+        v.assert(SafeInteger, idOrParams);
         request.url += `/${idOrParams}`;
       } else if (typeof idOrParams !== "undefined") {
         v.assert(ResetParameters, idOrParams);
@@ -191,7 +191,7 @@ export class ApiRequestFactory {
      * @throws A `TypeError` if trying to set type-checked request headers.
      * @throws A {@link valibot!ValiError} if ID or parameters are invalid.
      */
-    get: (idOrParams?: Integer | ReviewStatisticParameters, options?: ApiRequestOptions): ApiRequest => {
+    get: (idOrParams?: ReviewStatisticParameters | SafeInteger, options?: ApiRequestOptions): ApiRequest => {
       const headers = { ...this._getHeaders };
       if (typeof options?.customHeaders !== "undefined") {
         for (const [key, value] of Object.entries(options.customHeaders)) {
@@ -206,7 +206,7 @@ export class ApiRequestFactory {
         url: `${this.baseUrl}/review_statistics`,
       };
       if (typeof idOrParams === "number") {
-        v.assert(Integer, idOrParams);
+        v.assert(SafeInteger, idOrParams);
         request.url += `/${idOrParams}`;
       } else if (typeof idOrParams !== "undefined") {
         v.assert(ReviewStatisticParameters, idOrParams);
@@ -256,7 +256,7 @@ export class ApiRequestFactory {
      * @throws A `TypeError` if trying to set type-checked request headers.
      * @throws A {@link valibot!ValiError} if ID or parameters are invalid.
      */
-    get: (idOrParams?: Integer | ReviewParameters, options?: ApiRequestOptions): ApiRequest => {
+    get: (idOrParams?: ReviewParameters | SafeInteger, options?: ApiRequestOptions): ApiRequest => {
       const headers = { ...this._getHeaders };
       if (typeof options?.customHeaders !== "undefined") {
         for (const [key, value] of Object.entries(options.customHeaders)) {
@@ -271,7 +271,7 @@ export class ApiRequestFactory {
         url: `${this.baseUrl}/reviews`,
       };
       if (typeof idOrParams === "number") {
-        v.assert(Integer, idOrParams);
+        v.assert(SafeInteger, idOrParams);
         request.url += `/${idOrParams}`;
       } else if (typeof idOrParams !== "undefined") {
         v.assert(ReviewParameters, idOrParams);
@@ -294,7 +294,7 @@ export class ApiRequestFactory {
      * @throws A `TypeError` if trying to set type-checked request headers.
      * @throws A {@link valibot!ValiError} if ID or parameters are invalid.
      */
-    get: (idOrParams?: Integer | SpacedRepetitionSystemParameters, options?: ApiRequestOptions): ApiRequest => {
+    get: (idOrParams?: SafeInteger | SpacedRepetitionSystemParameters, options?: ApiRequestOptions): ApiRequest => {
       const headers = { ...this._getHeaders };
       if (typeof options?.customHeaders !== "undefined") {
         for (const [key, value] of Object.entries(options.customHeaders)) {
@@ -309,7 +309,7 @@ export class ApiRequestFactory {
         url: `${this.baseUrl}/spaced_repetition_systems`,
       };
       if (typeof idOrParams === "number") {
-        v.assert(Integer, idOrParams);
+        v.assert(SafeInteger, idOrParams);
         request.url += `/${idOrParams}`;
       } else if (typeof idOrParams !== "undefined") {
         v.assert(SpacedRepetitionSystemParameters, idOrParams);
@@ -332,7 +332,7 @@ export class ApiRequestFactory {
      * @throws A `TypeError` if trying to set type-checked request headers.
      * @throws A {@link valibot!ValiError} if ID or parameters are invalid.
      */
-    get: (idOrParams?: Integer | StudyMaterialParameters, options?: ApiRequestOptions): ApiRequest => {
+    get: (idOrParams?: SafeInteger | StudyMaterialParameters, options?: ApiRequestOptions): ApiRequest => {
       const headers = { ...this._getHeaders };
       if (typeof options?.customHeaders !== "undefined") {
         for (const [key, value] of Object.entries(options.customHeaders)) {
@@ -347,7 +347,7 @@ export class ApiRequestFactory {
         url: `${this.baseUrl}/study_materials`,
       };
       if (typeof idOrParams === "number") {
-        v.assert(Integer, idOrParams);
+        v.assert(SafeInteger, idOrParams);
         request.url += `/${idOrParams}`;
       } else if (typeof idOrParams !== "undefined") {
         v.assert(StudyMaterialParameters, idOrParams);
@@ -394,11 +394,11 @@ export class ApiRequestFactory {
      * @throws A {@link valibot!ValiError} if ID or payload is invalid.
      */
     update: (
-      studyMaterialId: Integer,
+      studyMaterialId: SafeInteger,
       payload: StudyMaterialUpdatePayload,
       options?: ApiRequestOptions,
     ): ApiRequest => {
-      v.assert(Integer, studyMaterialId);
+      v.assert(SafeInteger, studyMaterialId);
       v.assert(StudyMaterialUpdatePayload, payload);
       const headers = { ...this._postPutHeaders };
       if (typeof options !== "undefined") {
@@ -431,7 +431,7 @@ export class ApiRequestFactory {
      * @throws A `TypeError` if trying to set type-checked request headers.
      * @throws A {@link valibot!ValiError} if ID or parameters are invalid.
      */
-    get: (idOrParams?: Integer | SubjectParameters, options?: ApiRequestOptions): ApiRequest => {
+    get: (idOrParams?: SafeInteger | SubjectParameters, options?: ApiRequestOptions): ApiRequest => {
       const headers = { ...this._getHeaders };
       if (typeof options?.customHeaders !== "undefined") {
         for (const [key, value] of Object.entries(options.customHeaders)) {
@@ -446,7 +446,7 @@ export class ApiRequestFactory {
         url: `${this.baseUrl}/subjects`,
       };
       if (typeof idOrParams === "number") {
-        v.assert(Integer, idOrParams);
+        v.assert(SafeInteger, idOrParams);
         request.url += `/${idOrParams}`;
       } else if (typeof idOrParams !== "undefined") {
         v.assert(SubjectParameters, idOrParams);
@@ -554,7 +554,7 @@ export class ApiRequestFactory {
      * @returns A Get Voice Actor(s) Request usabile in any HTTP API/Library.
      * @throws A {@link valibot!ValiError} if ID or parameters are invalid.
      */
-    get: (idOrParams?: Integer | VoiceActorParameters, options?: ApiRequestOptions): ApiRequest => {
+    get: (idOrParams?: SafeInteger | VoiceActorParameters, options?: ApiRequestOptions): ApiRequest => {
       const headers = { ...this._getHeaders };
       if (typeof options?.customHeaders !== "undefined") {
         for (const [key, value] of Object.entries(options.customHeaders)) {
@@ -569,7 +569,7 @@ export class ApiRequestFactory {
         url: `${this.baseUrl}/voice_actors`,
       };
       if (typeof idOrParams === "number") {
-        v.assert(Integer, idOrParams);
+        v.assert(SafeInteger, idOrParams);
         request.url += `/${idOrParams}`;
       } else if (typeof idOrParams !== "undefined") {
         v.assert(VoiceActorParameters, idOrParams);

--- a/src/v20170710/requests.ts
+++ b/src/v20170710/requests.ts
@@ -1,5 +1,5 @@
 import * as v from "valibot";
-import { ApiRevision, stringifyParameters } from "./base.js";
+import { ApiRevision, Integer, stringifyParameters } from "./base.js";
 import { AssignmentParameters, AssignmentPayload } from "./assignments.js";
 import { ReviewParameters, ReviewPayload } from "./reviews.js";
 import { StudyMaterialCreatePayload, StudyMaterialParameters, StudyMaterialUpdatePayload } from "./study-materials.js";
@@ -45,7 +45,7 @@ export class ApiRequestFactory {
      * @param options Options for making GET requests to the API.
      * @returns A Get Assignment(s) Request usabile in any HTTP API/Library.
      */
-    get: (idOrParams?: AssignmentParameters | number, options?: ApiRequestOptions): ApiRequest => {
+    get: (idOrParams?: AssignmentParameters | Integer, options?: ApiRequestOptions): ApiRequest => {
       const headers = { ...this._getHeaders };
       if (typeof options?.customHeaders !== "undefined") {
         for (const [key, value] of Object.entries(options.customHeaders)) {
@@ -60,6 +60,7 @@ export class ApiRequestFactory {
         url: `${this.baseUrl}/assignments`,
       };
       if (typeof idOrParams === "number") {
+        v.assert(Integer, idOrParams);
         request.url += `/${idOrParams}`;
       } else if (typeof idOrParams !== "undefined") {
         v.assert(AssignmentParameters, idOrParams);
@@ -75,7 +76,8 @@ export class ApiRequestFactory {
      * @param options Options for making PUT requests to the API.
      * @returns A Start Assignment Request usable in any HTTP API/Library.
      */
-    start: (assignmentId: number, payload: AssignmentPayload, options?: ApiRequestOptions): ApiRequest => {
+    start: (assignmentId: Integer, payload: AssignmentPayload, options?: ApiRequestOptions): ApiRequest => {
+      v.assert(Integer, assignmentId);
       v.assert(AssignmentPayload, payload);
       const headers = { ...this._postPutHeaders };
       if (typeof options?.customHeaders !== "undefined") {
@@ -108,7 +110,7 @@ export class ApiRequestFactory {
      * @param options Options for making GET requests to the API.
      * @returns A Get Level Progression(s) Request usabile in any HTTP API/Library.
      */
-    get: (idOrParams?: LevelProgressionParameters | number, options?: ApiRequestOptions): ApiRequest => {
+    get: (idOrParams?: Integer | LevelProgressionParameters, options?: ApiRequestOptions): ApiRequest => {
       const headers = { ...this._getHeaders };
       if (typeof options?.customHeaders !== "undefined") {
         for (const [key, value] of Object.entries(options.customHeaders)) {
@@ -123,6 +125,7 @@ export class ApiRequestFactory {
         url: `${this.baseUrl}/level_progressions`,
       };
       if (typeof idOrParams === "number") {
+        v.assert(Integer, idOrParams);
         request.url += `/${idOrParams}`;
       } else if (typeof idOrParams !== "undefined") {
         v.assert(LevelProgressionParameters, idOrParams);
@@ -142,7 +145,7 @@ export class ApiRequestFactory {
      * @param options Options for making GET requests to the API.
      * @returns A Get Reset(s) Request usabile in any HTTP API/Library.
      */
-    get: (idOrParams?: ResetParameters | number, options?: ApiRequestOptions): ApiRequest => {
+    get: (idOrParams?: Integer | ResetParameters, options?: ApiRequestOptions): ApiRequest => {
       const headers = { ...this._getHeaders };
       if (typeof options?.customHeaders !== "undefined") {
         for (const [key, value] of Object.entries(options.customHeaders)) {
@@ -157,6 +160,7 @@ export class ApiRequestFactory {
         url: `${this.baseUrl}/resets`,
       };
       if (typeof idOrParams === "number") {
+        v.assert(Integer, idOrParams);
         request.url += `/${idOrParams}`;
       } else if (typeof idOrParams !== "undefined") {
         v.assert(ResetParameters, idOrParams);
@@ -177,7 +181,7 @@ export class ApiRequestFactory {
      * @param options Options for making GET requests to the API.
      * @returns A Get Review Statistic(s) Request usabile in any HTTP API/Library.
      */
-    get: (idOrParams?: ReviewStatisticParameters | number, options?: ApiRequestOptions): ApiRequest => {
+    get: (idOrParams?: Integer | ReviewStatisticParameters, options?: ApiRequestOptions): ApiRequest => {
       const headers = { ...this._getHeaders };
       if (typeof options?.customHeaders !== "undefined") {
         for (const [key, value] of Object.entries(options.customHeaders)) {
@@ -192,6 +196,7 @@ export class ApiRequestFactory {
         url: `${this.baseUrl}/review_statistics`,
       };
       if (typeof idOrParams === "number") {
+        v.assert(Integer, idOrParams);
         request.url += `/${idOrParams}`;
       } else if (typeof idOrParams !== "undefined") {
         v.assert(ReviewStatisticParameters, idOrParams);
@@ -237,7 +242,7 @@ export class ApiRequestFactory {
      * @param options Options for making GET requests to the API.
      * @returns A Get Review(s) Request usabile in any HTTP API/Library.
      */
-    get: (idOrParams?: ReviewParameters | number, options?: ApiRequestOptions): ApiRequest => {
+    get: (idOrParams?: Integer | ReviewParameters, options?: ApiRequestOptions): ApiRequest => {
       const headers = { ...this._getHeaders };
       if (typeof options?.customHeaders !== "undefined") {
         for (const [key, value] of Object.entries(options.customHeaders)) {
@@ -252,6 +257,7 @@ export class ApiRequestFactory {
         url: `${this.baseUrl}/reviews`,
       };
       if (typeof idOrParams === "number") {
+        v.assert(Integer, idOrParams);
         request.url += `/${idOrParams}`;
       } else if (typeof idOrParams !== "undefined") {
         v.assert(ReviewParameters, idOrParams);
@@ -272,7 +278,7 @@ export class ApiRequestFactory {
      * @param options Options for making GET requests to the API.
      * @returns A Get Spaced Repetition System(s) (SRS) Request usabile in any HTTP API/Library.
      */
-    get: (idOrParams?: SpacedRepetitionSystemParameters | number, options?: ApiRequestOptions): ApiRequest => {
+    get: (idOrParams?: Integer | SpacedRepetitionSystemParameters, options?: ApiRequestOptions): ApiRequest => {
       const headers = { ...this._getHeaders };
       if (typeof options?.customHeaders !== "undefined") {
         for (const [key, value] of Object.entries(options.customHeaders)) {
@@ -287,6 +293,7 @@ export class ApiRequestFactory {
         url: `${this.baseUrl}/spaced_repetition_systems`,
       };
       if (typeof idOrParams === "number") {
+        v.assert(Integer, idOrParams);
         request.url += `/${idOrParams}`;
       } else if (typeof idOrParams !== "undefined") {
         v.assert(SpacedRepetitionSystemParameters, idOrParams);
@@ -307,7 +314,7 @@ export class ApiRequestFactory {
      * @param options Options for making GET requests to the API.
      * @returns A Get Study Material(s) Request usabile in any HTTP API/Library.
      */
-    get: (idOrParams?: StudyMaterialParameters | number, options?: ApiRequestOptions): ApiRequest => {
+    get: (idOrParams?: Integer | StudyMaterialParameters, options?: ApiRequestOptions): ApiRequest => {
       const headers = { ...this._getHeaders };
       if (typeof options?.customHeaders !== "undefined") {
         for (const [key, value] of Object.entries(options.customHeaders)) {
@@ -322,6 +329,7 @@ export class ApiRequestFactory {
         url: `${this.baseUrl}/study_materials`,
       };
       if (typeof idOrParams === "number") {
+        v.assert(Integer, idOrParams);
         request.url += `/${idOrParams}`;
       } else if (typeof idOrParams !== "undefined") {
         v.assert(StudyMaterialParameters, idOrParams);
@@ -363,7 +371,12 @@ export class ApiRequestFactory {
      * @param options Options for making PUT requests to the API.
      * @returns An Update Study Material Request usabile in any HTTP API/Library.
      */
-    update: (studyMaterialId: number, payload: StudyMaterialUpdatePayload, options?: ApiRequestOptions): ApiRequest => {
+    update: (
+      studyMaterialId: Integer,
+      payload: StudyMaterialUpdatePayload,
+      options?: ApiRequestOptions,
+    ): ApiRequest => {
+      v.assert(Integer, studyMaterialId);
       v.assert(StudyMaterialUpdatePayload, payload);
       const headers = { ...this._postPutHeaders };
       if (typeof options !== "undefined") {
@@ -394,7 +407,7 @@ export class ApiRequestFactory {
      * @param options Options for making GET requests to the API.
      * @returns A Get Subject(s) Request usabile in any HTTP API/Library.
      */
-    get: (idOrParams?: SubjectParameters | number, options?: ApiRequestOptions): ApiRequest => {
+    get: (idOrParams?: Integer | SubjectParameters, options?: ApiRequestOptions): ApiRequest => {
       const headers = { ...this._getHeaders };
       if (typeof options?.customHeaders !== "undefined") {
         for (const [key, value] of Object.entries(options.customHeaders)) {
@@ -409,6 +422,7 @@ export class ApiRequestFactory {
         url: `${this.baseUrl}/subjects`,
       };
       if (typeof idOrParams === "number") {
+        v.assert(Integer, idOrParams);
         request.url += `/${idOrParams}`;
       } else if (typeof idOrParams !== "undefined") {
         v.assert(SubjectParameters, idOrParams);
@@ -511,7 +525,7 @@ export class ApiRequestFactory {
      * @param options Options for making GET requests to the API.
      * @returns A Get Voice Actor(s) Request usabile in any HTTP API/Library.
      */
-    get: (idOrParams?: VoiceActorParameters | number, options?: ApiRequestOptions): ApiRequest => {
+    get: (idOrParams?: Integer | VoiceActorParameters, options?: ApiRequestOptions): ApiRequest => {
       const headers = { ...this._getHeaders };
       if (typeof options?.customHeaders !== "undefined") {
         for (const [key, value] of Object.entries(options.customHeaders)) {
@@ -526,6 +540,7 @@ export class ApiRequestFactory {
         url: `${this.baseUrl}/voice_actors`,
       };
       if (typeof idOrParams === "number") {
+        v.assert(Integer, idOrParams);
         request.url += `/${idOrParams}`;
       } else if (typeof idOrParams !== "undefined") {
         v.assert(VoiceActorParameters, idOrParams);

--- a/src/v20170710/requests.ts
+++ b/src/v20170710/requests.ts
@@ -44,6 +44,8 @@ export class ApiRequestFactory {
      * @param idOrParams The Assignment ID for individual Assignments, or parameters for Assignment Collections.
      * @param options Options for making GET requests to the API.
      * @returns A Get Assignment(s) Request usabile in any HTTP API/Library.
+     * @throws `TypeError` if trying to set type-checked request headers.
+     * @throws {@link valibot!ValiError} if ID or parameters are invalid.
      */
     get: (idOrParams?: AssignmentParameters | Integer, options?: ApiRequestOptions): ApiRequest => {
       const headers = { ...this._getHeaders };
@@ -75,6 +77,8 @@ export class ApiRequestFactory {
      * @param payload The payload to send when starting the Assignment.
      * @param options Options for making PUT requests to the API.
      * @returns A Start Assignment Request usable in any HTTP API/Library.
+     * @throws `TypeError` if trying to set type-checked request headers.
+     * @throws {@link valibot!ValiError} if ID or payload is invalid.
      */
     start: (assignmentId: Integer, payload: AssignmentPayload, options?: ApiRequestOptions): ApiRequest => {
       v.assert(Integer, assignmentId);
@@ -109,6 +113,8 @@ export class ApiRequestFactory {
      * Progression Collections.
      * @param options Options for making GET requests to the API.
      * @returns A Get Level Progression(s) Request usabile in any HTTP API/Library.
+     * @throws `TypeError` if trying to set type-checked request headers.
+     * @throws {@link valibot!ValiError} if ID or parameters are invalid.
      */
     get: (idOrParams?: Integer | LevelProgressionParameters, options?: ApiRequestOptions): ApiRequest => {
       const headers = { ...this._getHeaders };
@@ -144,6 +150,8 @@ export class ApiRequestFactory {
      * @param idOrParams The Reset ID for individual Resets, or parameters for Reset Collections.
      * @param options Options for making GET requests to the API.
      * @returns A Get Reset(s) Request usabile in any HTTP API/Library.
+     * @throws `TypeError` if trying to set type-checked request headers.
+     * @throws {@link valibot!ValiError} if ID or parameters are invalid.
      */
     get: (idOrParams?: Integer | ResetParameters, options?: ApiRequestOptions): ApiRequest => {
       const headers = { ...this._getHeaders };
@@ -180,6 +188,8 @@ export class ApiRequestFactory {
      * Collections.
      * @param options Options for making GET requests to the API.
      * @returns A Get Review Statistic(s) Request usabile in any HTTP API/Library.
+     * @throws `TypeError` if trying to set type-checked request headers.
+     * @throws {@link valibot!ValiError} if ID or parameters are invalid.
      */
     get: (idOrParams?: Integer | ReviewStatisticParameters, options?: ApiRequestOptions): ApiRequest => {
       const headers = { ...this._getHeaders };
@@ -215,6 +225,8 @@ export class ApiRequestFactory {
      * @param payload The payload to send when creating the Review.
      * @param options Options for making POST requests to the API.
      * @returns A Create Review Request usabile in any HTTP API/Library.
+     * @throws `TypeError` if trying to set type-checked request headers.
+     * @throws {@link valibot!ValiError} if ID or payload is invalid.
      */
     create: (payload: ReviewPayload, options?: ApiRequestOptions): ApiRequest => {
       v.assert(ReviewPayload, payload);
@@ -241,6 +253,8 @@ export class ApiRequestFactory {
      * @param idOrParams The Review ID for individual Reviews, or parameters for Review Collections.
      * @param options Options for making GET requests to the API.
      * @returns A Get Review(s) Request usabile in any HTTP API/Library.
+     * @throws `TypeError` if trying to set type-checked request headers.
+     * @throws {@link valibot!ValiError} if ID or parameters are invalid.
      */
     get: (idOrParams?: Integer | ReviewParameters, options?: ApiRequestOptions): ApiRequest => {
       const headers = { ...this._getHeaders };
@@ -277,6 +291,8 @@ export class ApiRequestFactory {
      * parameters for Spaced Repetition System (SRS) Collections.
      * @param options Options for making GET requests to the API.
      * @returns A Get Spaced Repetition System(s) (SRS) Request usabile in any HTTP API/Library.
+     * @throws `TypeError` if trying to set type-checked request headers.
+     * @throws {@link valibot!ValiError} if ID or parameters are invalid.
      */
     get: (idOrParams?: Integer | SpacedRepetitionSystemParameters, options?: ApiRequestOptions): ApiRequest => {
       const headers = { ...this._getHeaders };
@@ -313,6 +329,8 @@ export class ApiRequestFactory {
      * Collections.
      * @param options Options for making GET requests to the API.
      * @returns A Get Study Material(s) Request usabile in any HTTP API/Library.
+     * @throws `TypeError` if trying to set type-checked request headers.
+     * @throws {@link valibot!ValiError} if ID or parameters are invalid.
      */
     get: (idOrParams?: Integer | StudyMaterialParameters, options?: ApiRequestOptions): ApiRequest => {
       const headers = { ...this._getHeaders };
@@ -343,6 +361,8 @@ export class ApiRequestFactory {
      * @param payload The payload to send when creating the new Study Material.
      * @param options Options for making POST requests to the API.
      * @returns A Create Study Material Request usabile in any HTTP API/Library.
+     * @throws `TypeError` if trying to set type-checked request headers.
+     * @throws {@link valibot!ValiError} if payload is invalid.
      */
     create: (payload: StudyMaterialCreatePayload, options?: ApiRequestOptions): ApiRequest => {
       v.assert(StudyMaterialCreatePayload, payload);
@@ -370,6 +390,8 @@ export class ApiRequestFactory {
      * @param payload The payload to send when updating the Study Material.
      * @param options Options for making PUT requests to the API.
      * @returns An Update Study Material Request usabile in any HTTP API/Library.
+     * @throws `TypeError` if trying to set type-checked request headers.
+     * @throws {@link valibot!ValiError} if ID or payload is invalid.
      */
     update: (
       studyMaterialId: Integer,
@@ -406,6 +428,8 @@ export class ApiRequestFactory {
      * @param idOrParams The Subject ID for individual Subjects, or parameters for Subject Collections.
      * @param options Options for making GET requests to the API.
      * @returns A Get Subject(s) Request usabile in any HTTP API/Library.
+     * @throws `TypeError` if trying to set type-checked request headers.
+     * @throws {@link valibot!ValiError} if ID or parameters are invalid.
      */
     get: (idOrParams?: Integer | SubjectParameters, options?: ApiRequestOptions): ApiRequest => {
       const headers = { ...this._getHeaders };
@@ -441,6 +465,7 @@ export class ApiRequestFactory {
      *
      * @param options Options for making GET requests to the API.
      * @returns A Get Summary Request usabile in any HTTP API/Library.
+     * @throws `TypeError` if trying to set type-checked request headers.
      */
     get: (options?: ApiRequestOptions): ApiRequest => {
       const headers = { ...this._getHeaders };
@@ -469,6 +494,7 @@ export class ApiRequestFactory {
      *
      * @param options Options for making GET requests to the API.
      * @returns A Get User Request usabile in any HTTP API/Library.
+     * @throws `TypeError` if trying to set type-checked request headers.
      */
     get: (options?: ApiRequestOptions): ApiRequest => {
       const headers = { ...this._getHeaders };
@@ -493,6 +519,8 @@ export class ApiRequestFactory {
      * @param payload The payload containing changed Preferences to send for the update.
      * @param options Options for making PUT requests to the API.
      * @returns An Update User Preferences Request usabile in any HTTP API/Library.
+     * @throws `TypeError` if trying to set type-checked request headers.
+     * @throws {@link valibot!ValiError} if payload is invalid.
      */
     updatePreferences: (payload: UserPreferencesPayload, options?: ApiRequestOptions): ApiRequest => {
       v.assert(UserPreferencesPayload, payload);
@@ -524,6 +552,7 @@ export class ApiRequestFactory {
      * @param idOrParams The Voice Actor ID for individual Voice Actors, or parameters for Voice Actor Collections.
      * @param options Options for making GET requests to the API.
      * @returns A Get Voice Actor(s) Request usabile in any HTTP API/Library.
+     * @throws {@link valibot!ValiError} if ID or parameters are invalid.
      */
     get: (idOrParams?: Integer | VoiceActorParameters, options?: ApiRequestOptions): ApiRequest => {
       const headers = { ...this._getHeaders };

--- a/src/v20170710/requests.ts
+++ b/src/v20170710/requests.ts
@@ -226,7 +226,7 @@ export class ApiRequestFactory {
      * @param options Options for making POST requests to the API.
      * @returns A Create Review Request usabile in any HTTP API/Library.
      * @throws A `TypeError` if trying to set type-checked request headers.
-     * @throws A {@link valibot!ValiError} if ID or payload is invalid.
+     * @throws A {@link valibot!ValiError} if payload is invalid.
      */
     create: (payload: ReviewPayload, options?: ApiRequestOptions): ApiRequest => {
       v.assert(ReviewPayload, payload);

--- a/src/v20170710/requests.ts
+++ b/src/v20170710/requests.ts
@@ -44,8 +44,8 @@ export class ApiRequestFactory {
      * @param idOrParams The Assignment ID for individual Assignments, or parameters for Assignment Collections.
      * @param options Options for making GET requests to the API.
      * @returns A Get Assignment(s) Request usabile in any HTTP API/Library.
-     * @throws `TypeError` if trying to set type-checked request headers.
-     * @throws {@link valibot!ValiError} if ID or parameters are invalid.
+     * @throws A `TypeError` if trying to set type-checked request headers.
+     * @throws A {@link valibot!ValiError} if ID or parameters are invalid.
      */
     get: (idOrParams?: AssignmentParameters | Integer, options?: ApiRequestOptions): ApiRequest => {
       const headers = { ...this._getHeaders };
@@ -77,8 +77,8 @@ export class ApiRequestFactory {
      * @param payload The payload to send when starting the Assignment.
      * @param options Options for making PUT requests to the API.
      * @returns A Start Assignment Request usable in any HTTP API/Library.
-     * @throws `TypeError` if trying to set type-checked request headers.
-     * @throws {@link valibot!ValiError} if ID or payload is invalid.
+     * @throws A `TypeError` if trying to set type-checked request headers.
+     * @throws A {@link valibot!ValiError} if ID or payload is invalid.
      */
     start: (assignmentId: Integer, payload: AssignmentPayload, options?: ApiRequestOptions): ApiRequest => {
       v.assert(Integer, assignmentId);
@@ -113,8 +113,8 @@ export class ApiRequestFactory {
      * Progression Collections.
      * @param options Options for making GET requests to the API.
      * @returns A Get Level Progression(s) Request usabile in any HTTP API/Library.
-     * @throws `TypeError` if trying to set type-checked request headers.
-     * @throws {@link valibot!ValiError} if ID or parameters are invalid.
+     * @throws A `TypeError` if trying to set type-checked request headers.
+     * @throws A {@link valibot!ValiError} if ID or parameters are invalid.
      */
     get: (idOrParams?: Integer | LevelProgressionParameters, options?: ApiRequestOptions): ApiRequest => {
       const headers = { ...this._getHeaders };
@@ -150,8 +150,8 @@ export class ApiRequestFactory {
      * @param idOrParams The Reset ID for individual Resets, or parameters for Reset Collections.
      * @param options Options for making GET requests to the API.
      * @returns A Get Reset(s) Request usabile in any HTTP API/Library.
-     * @throws `TypeError` if trying to set type-checked request headers.
-     * @throws {@link valibot!ValiError} if ID or parameters are invalid.
+     * @throws A `TypeError` if trying to set type-checked request headers.
+     * @throws A {@link valibot!ValiError} if ID or parameters are invalid.
      */
     get: (idOrParams?: Integer | ResetParameters, options?: ApiRequestOptions): ApiRequest => {
       const headers = { ...this._getHeaders };
@@ -188,8 +188,8 @@ export class ApiRequestFactory {
      * Collections.
      * @param options Options for making GET requests to the API.
      * @returns A Get Review Statistic(s) Request usabile in any HTTP API/Library.
-     * @throws `TypeError` if trying to set type-checked request headers.
-     * @throws {@link valibot!ValiError} if ID or parameters are invalid.
+     * @throws A `TypeError` if trying to set type-checked request headers.
+     * @throws A {@link valibot!ValiError} if ID or parameters are invalid.
      */
     get: (idOrParams?: Integer | ReviewStatisticParameters, options?: ApiRequestOptions): ApiRequest => {
       const headers = { ...this._getHeaders };
@@ -225,8 +225,8 @@ export class ApiRequestFactory {
      * @param payload The payload to send when creating the Review.
      * @param options Options for making POST requests to the API.
      * @returns A Create Review Request usabile in any HTTP API/Library.
-     * @throws `TypeError` if trying to set type-checked request headers.
-     * @throws {@link valibot!ValiError} if ID or payload is invalid.
+     * @throws A `TypeError` if trying to set type-checked request headers.
+     * @throws A {@link valibot!ValiError} if ID or payload is invalid.
      */
     create: (payload: ReviewPayload, options?: ApiRequestOptions): ApiRequest => {
       v.assert(ReviewPayload, payload);
@@ -253,8 +253,8 @@ export class ApiRequestFactory {
      * @param idOrParams The Review ID for individual Reviews, or parameters for Review Collections.
      * @param options Options for making GET requests to the API.
      * @returns A Get Review(s) Request usabile in any HTTP API/Library.
-     * @throws `TypeError` if trying to set type-checked request headers.
-     * @throws {@link valibot!ValiError} if ID or parameters are invalid.
+     * @throws A `TypeError` if trying to set type-checked request headers.
+     * @throws A {@link valibot!ValiError} if ID or parameters are invalid.
      */
     get: (idOrParams?: Integer | ReviewParameters, options?: ApiRequestOptions): ApiRequest => {
       const headers = { ...this._getHeaders };
@@ -291,8 +291,8 @@ export class ApiRequestFactory {
      * parameters for Spaced Repetition System (SRS) Collections.
      * @param options Options for making GET requests to the API.
      * @returns A Get Spaced Repetition System(s) (SRS) Request usabile in any HTTP API/Library.
-     * @throws `TypeError` if trying to set type-checked request headers.
-     * @throws {@link valibot!ValiError} if ID or parameters are invalid.
+     * @throws A `TypeError` if trying to set type-checked request headers.
+     * @throws A {@link valibot!ValiError} if ID or parameters are invalid.
      */
     get: (idOrParams?: Integer | SpacedRepetitionSystemParameters, options?: ApiRequestOptions): ApiRequest => {
       const headers = { ...this._getHeaders };
@@ -329,8 +329,8 @@ export class ApiRequestFactory {
      * Collections.
      * @param options Options for making GET requests to the API.
      * @returns A Get Study Material(s) Request usabile in any HTTP API/Library.
-     * @throws `TypeError` if trying to set type-checked request headers.
-     * @throws {@link valibot!ValiError} if ID or parameters are invalid.
+     * @throws A `TypeError` if trying to set type-checked request headers.
+     * @throws A {@link valibot!ValiError} if ID or parameters are invalid.
      */
     get: (idOrParams?: Integer | StudyMaterialParameters, options?: ApiRequestOptions): ApiRequest => {
       const headers = { ...this._getHeaders };
@@ -361,8 +361,8 @@ export class ApiRequestFactory {
      * @param payload The payload to send when creating the new Study Material.
      * @param options Options for making POST requests to the API.
      * @returns A Create Study Material Request usabile in any HTTP API/Library.
-     * @throws `TypeError` if trying to set type-checked request headers.
-     * @throws {@link valibot!ValiError} if payload is invalid.
+     * @throws A `TypeError` if trying to set type-checked request headers.
+     * @throws A {@link valibot!ValiError} if payload is invalid.
      */
     create: (payload: StudyMaterialCreatePayload, options?: ApiRequestOptions): ApiRequest => {
       v.assert(StudyMaterialCreatePayload, payload);
@@ -390,8 +390,8 @@ export class ApiRequestFactory {
      * @param payload The payload to send when updating the Study Material.
      * @param options Options for making PUT requests to the API.
      * @returns An Update Study Material Request usabile in any HTTP API/Library.
-     * @throws `TypeError` if trying to set type-checked request headers.
-     * @throws {@link valibot!ValiError} if ID or payload is invalid.
+     * @throws A `TypeError` if trying to set type-checked request headers.
+     * @throws A {@link valibot!ValiError} if ID or payload is invalid.
      */
     update: (
       studyMaterialId: Integer,
@@ -428,8 +428,8 @@ export class ApiRequestFactory {
      * @param idOrParams The Subject ID for individual Subjects, or parameters for Subject Collections.
      * @param options Options for making GET requests to the API.
      * @returns A Get Subject(s) Request usabile in any HTTP API/Library.
-     * @throws `TypeError` if trying to set type-checked request headers.
-     * @throws {@link valibot!ValiError} if ID or parameters are invalid.
+     * @throws A `TypeError` if trying to set type-checked request headers.
+     * @throws A {@link valibot!ValiError} if ID or parameters are invalid.
      */
     get: (idOrParams?: Integer | SubjectParameters, options?: ApiRequestOptions): ApiRequest => {
       const headers = { ...this._getHeaders };
@@ -465,7 +465,7 @@ export class ApiRequestFactory {
      *
      * @param options Options for making GET requests to the API.
      * @returns A Get Summary Request usabile in any HTTP API/Library.
-     * @throws `TypeError` if trying to set type-checked request headers.
+     * @throws A `TypeError` if trying to set type-checked request headers.
      */
     get: (options?: ApiRequestOptions): ApiRequest => {
       const headers = { ...this._getHeaders };
@@ -494,7 +494,7 @@ export class ApiRequestFactory {
      *
      * @param options Options for making GET requests to the API.
      * @returns A Get User Request usabile in any HTTP API/Library.
-     * @throws `TypeError` if trying to set type-checked request headers.
+     * @throws A `TypeError` if trying to set type-checked request headers.
      */
     get: (options?: ApiRequestOptions): ApiRequest => {
       const headers = { ...this._getHeaders };
@@ -519,8 +519,8 @@ export class ApiRequestFactory {
      * @param payload The payload containing changed Preferences to send for the update.
      * @param options Options for making PUT requests to the API.
      * @returns An Update User Preferences Request usabile in any HTTP API/Library.
-     * @throws `TypeError` if trying to set type-checked request headers.
-     * @throws {@link valibot!ValiError} if payload is invalid.
+     * @throws A `TypeError` if trying to set type-checked request headers.
+     * @throws A {@link valibot!ValiError} if payload is invalid.
      */
     updatePreferences: (payload: UserPreferencesPayload, options?: ApiRequestOptions): ApiRequest => {
       v.assert(UserPreferencesPayload, payload);
@@ -552,7 +552,7 @@ export class ApiRequestFactory {
      * @param idOrParams The Voice Actor ID for individual Voice Actors, or parameters for Voice Actor Collections.
      * @param options Options for making GET requests to the API.
      * @returns A Get Voice Actor(s) Request usabile in any HTTP API/Library.
-     * @throws {@link valibot!ValiError} if ID or parameters are invalid.
+     * @throws A {@link valibot!ValiError} if ID or parameters are invalid.
      */
     get: (idOrParams?: Integer | VoiceActorParameters, options?: ApiRequestOptions): ApiRequest => {
       const headers = { ...this._getHeaders };
@@ -598,6 +598,7 @@ export class ApiRequestFactory {
   /**
    * Initialize the Request Factory.
    * @param init Initialization options for the factory.
+   * @throws A `TypeError` if trying to set type-checked request headers.
    */
   public constructor(init: ApiRequestFactoryInit) {
     this._initHeaders = {
@@ -620,7 +621,7 @@ export class ApiRequestFactory {
    * Validates custom-set headers to make sure type checking isn't circumvented.
    * @param key The header key, e.g. `Accpet` or `X-Forwarded-For`
    * @param value The header value, e.g. `application/json` or `192.168.1.1`
-   * @throws A `TypeError` if there is an attempt to improperly set type-checked headers.
+   * @throws A `TypeError` if trying to set type-checked request headers.
    * @internal
    */
   private static _validateHeader(key: string, value: string): void {
@@ -640,6 +641,7 @@ export class ApiRequestFactory {
    * Add additional custom headers to be used in all requests generated by the factory.
    * @param headers An object containing HTTP headers and their values.
    * @returns The factory, with the added custom headers.
+   * @throws A `TypeError` if trying to set type-checked request headers.
    */
   public addCustomHeaders(headers: Record<string, string>): this {
     for (const [key, value] of Object.entries(headers)) {
@@ -654,6 +656,7 @@ export class ApiRequestFactory {
    * Sets a new WaniKani API Revision to use in requests returned by the factory.
    * @param revision The WaniKani API Revision to use.
    * @returns The factory, with the newly set WaniKani API Revision.
+   * @throws A {@link valibot!ValiError} if the WaniKani API Revision is invalid.
    */
   public setApiRevision(revision: ApiRevision): this {
     const validRevision = v.parse(ApiRevision, revision);
@@ -680,6 +683,7 @@ export class ApiRequestFactory {
    * previously set custom headers, and keeping API Revision and Token settings.
    * @param headers An object containing HTTP headers and their values.
    * @returns The factory, with the only custom headers being those passed to this function.
+   * @throws A `TypeError` if trying to set type-checked request headers.
    */
   public setCustomHeaders(headers: Record<string, string>): this {
     this._getHeaders = { ...this._initHeaders };

--- a/src/v20170710/review-statistics.ts
+++ b/src/v20170710/review-statistics.ts
@@ -1,5 +1,5 @@
 import * as v from "valibot";
-import { BaseCollection, BaseResource, CollectionParameters, DatableString, Integer } from "./base.js";
+import { BaseCollection, BaseResource, CollectionParameters, DatableString, SafeInteger } from "./base.js";
 import { SubjectTuple, SubjectType } from "./subjects.js";
 
 /**
@@ -190,7 +190,7 @@ export interface ReviewStatisticParameters extends CollectionParameters {
   /**
    * Only review statistics where `data.subject_id` matches one of the array values are returned.
    */
-  subject_ids?: Integer[];
+  subject_ids?: SafeInteger[];
 
   /**
    * Only review statistics where `data.subject_type` matches one of the array values are returned.
@@ -204,7 +204,7 @@ export const ReviewStatisticParameters = v.object(
       hidden: v.optional(v.boolean()),
       percentages_greater_than: v.optional(v.number()),
       percentages_less_than: v.optional(v.number()),
-      subject_ids: v.optional(v.array(Integer)),
+      subject_ids: v.optional(v.array(SafeInteger)),
       subject_types: v.optional(SubjectTuple),
     }),
   ]),

--- a/src/v20170710/review-statistics.ts
+++ b/src/v20170710/review-statistics.ts
@@ -1,5 +1,5 @@
 import * as v from "valibot";
-import { BaseCollection, BaseResource, CollectionParameters, DatableString } from "./base.js";
+import { BaseCollection, BaseResource, CollectionParameters, DatableString, Integer } from "./base.js";
 import { SubjectTuple, SubjectType } from "./subjects.js";
 
 /**
@@ -190,7 +190,7 @@ export interface ReviewStatisticParameters extends CollectionParameters {
   /**
    * Only review statistics where `data.subject_id` matches one of the array values are returned.
    */
-  subject_ids?: number[];
+  subject_ids?: Integer[];
 
   /**
    * Only review statistics where `data.subject_type` matches one of the array values are returned.
@@ -204,7 +204,7 @@ export const ReviewStatisticParameters = v.object(
       hidden: v.optional(v.boolean()),
       percentages_greater_than: v.optional(v.number()),
       percentages_less_than: v.optional(v.number()),
-      subject_ids: v.optional(v.array(v.number())),
+      subject_ids: v.optional(v.array(Integer)),
       subject_types: v.optional(SubjectTuple),
     }),
   ]),

--- a/src/v20170710/reviews.ts
+++ b/src/v20170710/reviews.ts
@@ -1,6 +1,6 @@
 import * as m from "./lang/index.js";
 import * as v from "valibot";
-import { BaseCollection, BaseResource, CollectionParameters, DatableString, Integer } from "./base.js";
+import { BaseCollection, BaseResource, CollectionParameters, DatableString, SafeInteger } from "./base.js";
 import { Assignment } from "./assignments.js";
 import { ReviewStatistic } from "./review-statistics.js";
 import { SpacedRepetitionSystemStageNumber } from "./spaced-repetition-systems.js";
@@ -147,19 +147,19 @@ export interface ReviewParameters extends CollectionParameters {
   /**
    * Only reviews where `data.assignment_id` matches one of the array values are returned.
    */
-  assignment_ids?: Integer[];
+  assignment_ids?: SafeInteger[];
 
   /**
    * Only reviews where `data.subject_id` matches one of the array values are returned.
    */
-  subject_ids?: Integer[];
+  subject_ids?: SafeInteger[];
 }
 export const ReviewParameters = v.object(
   v.entriesFromObjects([
     CollectionParameters,
     v.object({
-      assignment_ids: v.optional(v.array(Integer)),
-      subject_ids: v.optional(v.array(Integer)),
+      assignment_ids: v.optional(v.array(SafeInteger)),
+      subject_ids: v.optional(v.array(SafeInteger)),
     }),
   ]),
 );
@@ -179,13 +179,13 @@ export interface ReviewPayload {
     /**
      * Must be zero or a positive number. This is the number of times the meaning was answered incorrectly.
      */
-    incorrect_meaning_answers: Integer;
+    incorrect_meaning_answers: SafeInteger;
 
     /**
      * Must be zero or a positive number. This is the number of times the reading was answered incorrectly. Note that
      * subjects with a type of `radical` do not quiz on readings. Thus, set this value to `0`.
      */
-    incorrect_reading_answers: Integer;
+    incorrect_reading_answers: SafeInteger;
 
     /**
      * Timestamp when the review was completed. Defaults to the time of the request if omitted from the request body.
@@ -197,7 +197,7 @@ export interface ReviewPayload {
         /**
          * Unique identifier of the assignment. This or `subject_id` must be set.
          */
-        assignment_id: Integer;
+        assignment_id: SafeInteger;
 
         /**
          * The `subject_id` should not be set at the same time as `assignment_id`.
@@ -208,7 +208,7 @@ export interface ReviewPayload {
         /**
          * Unique identifier of the subject. This or `assignment_id` must be set.
          */
-        subject_id: Integer;
+        subject_id: SafeInteger;
 
         /**
          * The `assignment_id` should never be set at the same time as `subject_id`.
@@ -221,18 +221,18 @@ export const ReviewPayload = v.object({
   review: v.intersect(
     [
       v.object({
-        incorrect_meaning_answers: Integer,
-        incorrect_reading_answers: Integer,
+        incorrect_meaning_answers: SafeInteger,
+        incorrect_reading_answers: SafeInteger,
         created_at: v.optional(v.union([DatableString, v.date()], m.dateUnion)),
       }),
       v.union(
         [
           v.object({
-            assignment_id: Integer,
+            assignment_id: SafeInteger,
             subject_id: v.optional(v.never()),
           }),
           v.object({
-            subject_id: Integer,
+            subject_id: SafeInteger,
             assignment_id: v.optional(v.never()),
           }),
         ],

--- a/src/v20170710/reviews.ts
+++ b/src/v20170710/reviews.ts
@@ -1,6 +1,6 @@
 import * as m from "./lang/index.js";
 import * as v from "valibot";
-import { BaseCollection, BaseResource, CollectionParameters, DatableString } from "./base.js";
+import { BaseCollection, BaseResource, CollectionParameters, DatableString, Integer } from "./base.js";
 import { Assignment } from "./assignments.js";
 import { ReviewStatistic } from "./review-statistics.js";
 import { SpacedRepetitionSystemStageNumber } from "./spaced-repetition-systems.js";
@@ -147,19 +147,19 @@ export interface ReviewParameters extends CollectionParameters {
   /**
    * Only reviews where `data.assignment_id` matches one of the array values are returned.
    */
-  assignment_ids?: number[];
+  assignment_ids?: Integer[];
 
   /**
    * Only reviews where `data.subject_id` matches one of the array values are returned.
    */
-  subject_ids?: number[];
+  subject_ids?: Integer[];
 }
 export const ReviewParameters = v.object(
   v.entriesFromObjects([
     CollectionParameters,
     v.object({
-      assignment_ids: v.optional(v.array(v.number())),
-      subject_ids: v.optional(v.array(v.number())),
+      assignment_ids: v.optional(v.array(Integer)),
+      subject_ids: v.optional(v.array(Integer)),
     }),
   ]),
 );
@@ -179,13 +179,13 @@ export interface ReviewPayload {
     /**
      * Must be zero or a positive number. This is the number of times the meaning was answered incorrectly.
      */
-    incorrect_meaning_answers: number;
+    incorrect_meaning_answers: Integer;
 
     /**
      * Must be zero or a positive number. This is the number of times the reading was answered incorrectly. Note that
      * subjects with a type of `radical` do not quiz on readings. Thus, set this value to `0`.
      */
-    incorrect_reading_answers: number;
+    incorrect_reading_answers: Integer;
 
     /**
      * Timestamp when the review was completed. Defaults to the time of the request if omitted from the request body.
@@ -197,7 +197,7 @@ export interface ReviewPayload {
         /**
          * Unique identifier of the assignment. This or `subject_id` must be set.
          */
-        assignment_id: number;
+        assignment_id: Integer;
 
         /**
          * The `subject_id` should not be set at the same time as `assignment_id`.
@@ -208,7 +208,7 @@ export interface ReviewPayload {
         /**
          * Unique identifier of the subject. This or `assignment_id` must be set.
          */
-        subject_id: number;
+        subject_id: Integer;
 
         /**
          * The `assignment_id` should never be set at the same time as `subject_id`.
@@ -221,18 +221,18 @@ export const ReviewPayload = v.object({
   review: v.intersect(
     [
       v.object({
-        incorrect_meaning_answers: v.number(),
-        incorrect_reading_answers: v.number(),
+        incorrect_meaning_answers: Integer,
+        incorrect_reading_answers: Integer,
         created_at: v.optional(v.union([DatableString, v.date()], m.dateUnion)),
       }),
       v.union(
         [
           v.object({
-            assignment_id: v.number(),
+            assignment_id: Integer,
             subject_id: v.optional(v.never()),
           }),
           v.object({
-            subject_id: v.number(),
+            subject_id: Integer,
             assignment_id: v.optional(v.never()),
           }),
         ],

--- a/src/v20170710/spaced-repetition-systems.ts
+++ b/src/v20170710/spaced-repetition-systems.ts
@@ -1,5 +1,5 @@
 import * as v from "valibot";
-import { BaseCollection, BaseResource, CollectionParameters, DatableString, Integer } from "./base.js";
+import { BaseCollection, BaseResource, CollectionParameters, DatableString, SafeInteger } from "./base.js";
 
 /**
  * The minimum SRS Stage Number used in WaniKani's SRS; exported for use in lieu of a Magic Number.
@@ -28,7 +28,11 @@ export const MAX_SRS_STAGE = 9;
  * @category Spaced Repetition Systems
  */
 export type SpacedRepetitionSystemStageNumber = number & {};
-export const SpacedRepetitionSystemStageNumber = v.pipe(Integer, v.minValue(MIN_SRS_STAGE), v.maxValue(MAX_SRS_STAGE));
+export const SpacedRepetitionSystemStageNumber = v.pipe(
+  SafeInteger,
+  v.minValue(MIN_SRS_STAGE),
+  v.maxValue(MAX_SRS_STAGE),
+);
 
 /**
  * A type guard that checks if the given value matches the type predicate.

--- a/src/v20170710/spaced-repetition-systems.ts
+++ b/src/v20170710/spaced-repetition-systems.ts
@@ -1,5 +1,5 @@
 import * as v from "valibot";
-import { BaseCollection, BaseResource, CollectionParameters, DatableString } from "./base.js";
+import { BaseCollection, BaseResource, CollectionParameters, DatableString, Integer } from "./base.js";
 
 /**
  * The minimum SRS Stage Number used in WaniKani's SRS; exported for use in lieu of a Magic Number.
@@ -28,12 +28,7 @@ export const MAX_SRS_STAGE = 9;
  * @category Spaced Repetition Systems
  */
 export type SpacedRepetitionSystemStageNumber = number & {};
-export const SpacedRepetitionSystemStageNumber = v.pipe(
-  v.number(),
-  v.integer(),
-  v.minValue(MIN_SRS_STAGE),
-  v.maxValue(MAX_SRS_STAGE),
-);
+export const SpacedRepetitionSystemStageNumber = v.pipe(Integer, v.minValue(MIN_SRS_STAGE), v.maxValue(MAX_SRS_STAGE));
 
 /**
  * A type guard that checks if the given value matches the type predicate.

--- a/src/v20170710/study-materials.ts
+++ b/src/v20170710/study-materials.ts
@@ -1,5 +1,5 @@
 import * as v from "valibot";
-import { BaseCollection, BaseResource, CollectionParameters, DatableString } from "./base.js";
+import { BaseCollection, BaseResource, CollectionParameters, DatableString, Integer } from "./base.js";
 import { SubjectTuple, SubjectType } from "./subjects.js";
 
 /**
@@ -155,7 +155,7 @@ export interface StudyMaterialParameters extends CollectionParameters {
   /**
    * Only study material records where `data.subject_id` matches one of the array values are returned.
    */
-  subject_ids?: number[];
+  subject_ids?: Integer[];
 
   /**
    * Only study material records where `data.subject_type` matches one of the array values are returned.
@@ -167,7 +167,7 @@ export const StudyMaterialParameters = v.object(
     CollectionParameters,
     v.object({
       hidden: v.optional(v.boolean()),
-      subject_ids: v.optional(v.array(v.number())),
+      subject_ids: v.optional(v.array(Integer)),
       subject_types: v.optional(SubjectTuple),
     }),
   ]),
@@ -194,13 +194,13 @@ export interface StudyMaterialCreatePayload extends StudyMaterialUpdatePayload {
   /**
    * Unique identifier of the associated subject.
    */
-  subject_id: number;
+  subject_id: Integer;
 }
 export const StudyMaterialCreatePayload = v.object(
   v.entriesFromObjects([
     StudyMaterialUpdatePayload,
     v.object({
-      subject_id: v.number(),
+      subject_id: Integer,
     }),
   ]),
 );

--- a/src/v20170710/study-materials.ts
+++ b/src/v20170710/study-materials.ts
@@ -1,5 +1,5 @@
 import * as v from "valibot";
-import { BaseCollection, BaseResource, CollectionParameters, DatableString, Integer } from "./base.js";
+import { BaseCollection, BaseResource, CollectionParameters, DatableString, SafeInteger } from "./base.js";
 import { SubjectTuple, SubjectType } from "./subjects.js";
 
 /**
@@ -155,7 +155,7 @@ export interface StudyMaterialParameters extends CollectionParameters {
   /**
    * Only study material records where `data.subject_id` matches one of the array values are returned.
    */
-  subject_ids?: Integer[];
+  subject_ids?: SafeInteger[];
 
   /**
    * Only study material records where `data.subject_type` matches one of the array values are returned.
@@ -167,7 +167,7 @@ export const StudyMaterialParameters = v.object(
     CollectionParameters,
     v.object({
       hidden: v.optional(v.boolean()),
-      subject_ids: v.optional(v.array(Integer)),
+      subject_ids: v.optional(v.array(SafeInteger)),
       subject_types: v.optional(SubjectTuple),
     }),
   ]),
@@ -194,13 +194,13 @@ export interface StudyMaterialCreatePayload extends StudyMaterialUpdatePayload {
   /**
    * Unique identifier of the associated subject.
    */
-  subject_id: Integer;
+  subject_id: SafeInteger;
 }
 export const StudyMaterialCreatePayload = v.object(
   v.entriesFromObjects([
     StudyMaterialUpdatePayload,
     v.object({
-      subject_id: Integer,
+      subject_id: SafeInteger,
     }),
   ]),
 );

--- a/src/v20170710/user.ts
+++ b/src/v20170710/user.ts
@@ -1,5 +1,5 @@
 import * as v from "valibot";
-import { BaseResource, DatableString, Level } from "./base.js";
+import { BaseResource, DatableString, Integer, Level } from "./base.js";
 
 /**
  * The minimum batch size for lessons in the WaniKani app; exported for use in lieu of a Magic Number.
@@ -22,8 +22,7 @@ export const MAX_LESSON_BATCH_SIZE = 10;
  */
 export type LessonBatchSizeNumber = number & {};
 export const LessonBatchSizeNumber = v.pipe(
-  v.number(),
-  v.integer(),
+  Integer,
   v.minValue(MIN_LESSON_BATCH_SIZE),
   v.maxValue(MAX_LESSON_BATCH_SIZE),
 );
@@ -89,7 +88,7 @@ export interface UserPreferences {
   reviews_presentation_order: "lower_levels_first" | "shuffled";
 }
 export const UserPreferences = v.object({
-  default_voice_actor_id: v.number(),
+  default_voice_actor_id: Integer,
   extra_study_autoplay_audio: v.boolean(),
   lessons_autoplay_audio: v.boolean(),
   lessons_batch_size: LessonBatchSizeNumber,

--- a/src/v20170710/user.ts
+++ b/src/v20170710/user.ts
@@ -1,5 +1,5 @@
 import * as v from "valibot";
-import { BaseResource, DatableString, Integer, Level } from "./base.js";
+import { BaseResource, DatableString, Level, SafeInteger } from "./base.js";
 
 /**
  * The minimum batch size for lessons in the WaniKani app; exported for use in lieu of a Magic Number.
@@ -22,7 +22,7 @@ export const MAX_LESSON_BATCH_SIZE = 10;
  */
 export type LessonBatchSizeNumber = number & {};
 export const LessonBatchSizeNumber = v.pipe(
-  Integer,
+  SafeInteger,
   v.minValue(MIN_LESSON_BATCH_SIZE),
   v.maxValue(MAX_LESSON_BATCH_SIZE),
 );
@@ -88,7 +88,7 @@ export interface UserPreferences {
   reviews_presentation_order: "lower_levels_first" | "shuffled";
 }
 export const UserPreferences = v.object({
-  default_voice_actor_id: Integer,
+  default_voice_actor_id: SafeInteger,
   extra_study_autoplay_audio: v.boolean(),
   lessons_autoplay_audio: v.boolean(),
   lessons_batch_size: LessonBatchSizeNumber,

--- a/typedoc.json
+++ b/typedoc.json
@@ -5,6 +5,11 @@
   "plugin": ["./typedoc/plugin.js"],
   "router": "cloudflare",
   "sourceLinkTemplate": "https://github.com/bachman-dev/wanikani-api-types/blob/{gitRevision}/{path}#L{line}",
+  "externalSymbolLinkMappings": {
+    "valibot": {
+      "ValiError": "https://valibot.dev/api/ValiError/"
+    }
+  },
   "cleanOutputDir": true,
   "includeVersion": true,
   "categorizeByGroup": false,


### PR DESCRIPTION
# Description

This PR adds integer (whole number) validation to all submitted ID fields (parameters, payloads, etc.). All WaniKani resource IDs are whole numbers, so this will help catch the issue before making a request that will fail.

# Related Issue(s) / Pull Request(s)

None

# Nature of Pull Request

This Pull Request:

- [ ] Adds/Updates Type(s) described in the WaniKani API Docs
- [x] Adds/Updates Type(s) provided by the `wanikani-api-types` package itself
- [x] Adds/Updates constants or other variables provided by the package
- [ ] Adds/Updates Helper Functions/Type Guards provided by the package
- [x] Updates Documentation
- [ ] Updates Project and/or Community Health files (e.g. README, GitHub Actions, etc.)

Its changes constitutes a:

- [ ] Non-code change (i.e. no version bump)
- [ ] Bug Fix or Other Small Changes (i.e. patch version bump)
- [x] Forward-compatible Enhancement (i.e. minor version bump)
- [ ] ⚠️ BREAKING CHANGE regarding TypeScript, Package, and/or WaniKani API version(s) (i.e. MAJOR version bump)

# Additional Info

None

# Contribution Terms

I understand that by submitting this Pull Request:

- I agree to the terms outlined in the [Contribution Guidelines](https://github.com/bachman-dev/wanikani-api-types/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/bachman-dev/wanikani-api-types/blob/main/CODE_OF_CONDUCT.md)
- My code will be licensed for use in this repository per its [LICENSE](https://github.com/bachman-dev/wanikani-api-types/blob/main/LICENSE), and that I have the right to license this code -- per GitHub's [Terms of Service](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service#6-contributions-under-repository-license)
