### PR TITLE
Docs: Update Examples, Add Upgrade Guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ Fork and then clone the repo from GitHub into a location of your choosing. It's 
 Install the dependencies.
 
 ```shell
-npm install
+pnpm install
 ```
 
 After checking out a new branch, make any needed changes, and run all scripts defined in the `package.json`.

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -1,3 +1,8 @@
+---
+title: Examples
+category: Guides
+---
+
 # Examples
 
 Below are some code examples to illustrate the various types, constants, and functions available in the library.

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -14,13 +14,9 @@ Keep in mind these are very simple examples, and you might want to make addition
 These examples all assume you've set an environment variable, `WANIKANI_API_TOKEN`, for API authorization. Add the following code before using these examples pertaining to your JavaScript runtime.
 
 ```typescript
-// NodeJS: run node with --env-file option
+// NodeJS / Deno: Run with --env-file option
 // Bun: Reads .env automatically, else use --env-file option
 const WANIKANI_API_TOKEN = process.env("WANIKANI_API_TOKEN");
-
-// Deno -- deno add jsr:@std/dotenv/load
-import "@std/dotenv/load";
-const WANIKANI_API_TOKEN = Deno.env.get("WANIKANI_API_TOKEN");
 ```
 
 ## Get a 24-Hour Review Forecast
@@ -28,12 +24,7 @@ const WANIKANI_API_TOKEN = Deno.env.get("WANIKANI_API_TOKEN");
 Maybe you want a bar/line graph of your review workload for the day...
 
 ```typescript
-import {
-  type WKError,
-  WKRequestFactory,
-  type WKSummary,
-  WK_API_REVISION,
-} from "@bachman-dev/wanikani-api-types/v20170710";
+import * as WK from "@bachman-dev/wanikani-api-types/v20170710";
 
 interface WaniKaniReviewForecast {
   date: Date;
@@ -41,30 +32,38 @@ interface WaniKaniReviewForecast {
 }
 
 async function reviewForecast(): Promise<WaniKaniReviewForecast[]> {
-  const request = new WKRequestFactory({ apiToken: WANIKANI_API_TOKEN, revision: WK_API_REVISION }).summary.get();
+  const request = new ApiRequestFactory({ apiToken: WANIKANI_API_TOKEN, revision: WK_API_REVISION }).summary.get();
   const { method, url, headers } = request;
   const init = { method, headers };
   const response = await fetch(url, init);
   if (response.ok) {
-    const summary = (await response.json()) as WKSummary;
-    const initialForecast: WaniKaniReviewForecast[] = [];
-    summary.data.reviews.forEach((review) => {
-      initialForecast.push({
-        date: new Date(review.available_at),
-        reviews: review.subject_ids.length,
+    const summary = await response.json();
+    if (WK.isSummary(summary)) {
+      const initialForecast: WaniKaniReviewForecast[] = [];
+      summary.data.reviews.forEach((review) => {
+        initialForecast.push({
+          date: new Date(review.available_at),
+          reviews: review.subject_ids.length,
+        });
       });
-    });
-    const forecast = initialForecast.filter((item) => {
-      return item.reviews > 0;
-    });
-    return forecast;
-    /*
+      const forecast = initialForecast.filter((item) => {
+        return item.reviews > 0;
+      });
+      return forecast;
+      /*
       Or if you wanna include zeroes...
       return initialForecast;
-    */
+      */
+    } else {
+      throw new Error("Unexpected returned data from WaniKani API");
+    }
   } else {
-    const error = (await response.json()) as WKError;
-    throw new Error(error.error);
+    const error = await response.json();
+    if (WK.isApiError(error)) {
+      throw new Error(error.error);
+    } else {
+      throw new Error("Unknown WaniKani API Error");
+    }
   }
 }
 ```
@@ -74,187 +73,140 @@ async function reviewForecast(): Promise<WaniKaniReviewForecast[]> {
 A very wide collection of subjects, but can be limited by level.
 
 ```typescript
-import {
-  type WKError,
-  WKRequestFactory,
-  type WKSubjectCollection,
-  type WKSubjectData,
-  type WKSubjectParameters,
-  WK_API_REVISION,
-  isWKLevel,
-} from "@bachman-dev/wanikani-api-types/v20170710";
+import * as WK from "@bachman-dev/wanikani-api-types/v20170710";
 
-async function getSubjects(level?: number): Promise<WKSubjectData[]> {
-  if (typeof level !== "undefined" && !isWKLevel(level)) {
-    throw new TypeError("Invalid WaniKani Level! It must be a whole number between 1 and 60");
-  }
-  const params: WKSubjectParameters = {
+async function getSubjects(level?: WK.Level): Promise<WK.Subject[]> {
+  const params: WK.SubjectParameters = {
     hidden: false,
   };
-  if (typeof level !== "undefined") {
+  if (typeof level === "number") {
     params.levels = [level];
   }
-  const request = new WKRequestFactory({ apiToken: WANIKANI_API_TOKEN, revision: WK_API_REVISION }).subjects.get(
+  const request = new ApiRequestFactory({ apiToken: WANIKANI_API_TOKEN, revision: WK_API_REVISION }).subjects.get(
     params,
   );
   const { headers, method } = request;
   let { url } = request;
   const init = { headers, method };
   let response = await fetch(url, init);
-  let subjects = (await response.json()) as WKSubjectCollection | WKError;
-  const subjectData: WKSubjectData[] = [];
+  let json = await response.json();
+  const subjects: WK.Subject[] = [];
   let moreSubjects = true;
   while (moreSubjects) {
-    if (typeof subjects.data === "undefined" || typeof subjects.pages === "undefined") {
-      throw new Error(subjects.error);
-    }
-    subjects.data.forEach((subject) => {
-      subjectData.push(subject.data);
-    });
-    if (typeof subjects.pages !== "undefined" && subjects.pages.next_url !== null) {
-      url = subjects.pages.next_url;
-      response = await fetch(url, init);
-      subjects = (await response.json()) as WKSubjectCollection | WKError;
+    if (WK.isSubjectCollection(json)) {
+      json.data.forEach((subject) => {
+        subjects.push(subject);
+      });
+      if (json.pages.next_url !== null) {
+        url = json.pages.next_url;
+        response = await fetch(url, init);
+        json = await response.json();
+      } else {
+        moreSubjects = false;
+      }
+    } else if (WK.isApiError(json)) {
+      throw new Error(json.error);
     } else {
-      moreSubjects = false;
+      throw new Error("Unknown WaniKani API Error");
     }
   }
-  return subjectData;
+  return subjects;
 }
 ```
 
 ## Get Lessons
 
-Fetches all the info you need to display the lessons, hear pronunciation audio, and which assignments to start after the quiz. It also respects the user's lesson presentation and batch size preferences.
+Fetches all the info you need to display the lessons, hear pronunciation audio, and which assignments to start after the quiz. It also respects the user's lesson batch size preferences.
 
 ```typescript
-import {
-  type WKAssignmentCollection,
-  type WKAssignmentData,
-  type WKAssignmentParameters,
-  type WKError,
-  type WKLevel,
-  WKRequestFactory,
-  type WKSubjectCollection,
-  type WKSubjectData,
-  type WKSubjectParameters,
-  type WKUser,
-  WK_API_REVISION,
-} from "@bachman-dev/wanikani-api-types/v20170710";
+import * as WK from "@bachman-dev/wanikani-api-types/v20170710";
 
 interface WaniKaniLesson {
-  subject: WKSubjectData;
-  assignment: WKAssignmentData;
+  subject: WK.Subject;
+  assignment: WK.Assignment;
 }
 
-type WaniKaniLessonLevels = Partial<Record<WKLevel, WaniKaniLesson[]>>;
+type WaniKaniLessonLevels = Partial<Record<WK.Level, WaniKaniLesson[]>>;
 
 async function getLessons(): Promise<WaniKaniLesson[]> {
-  const wk = new WKRequestFactory({ apiToken: WANIKANI_API_TOKEN, revision: WK_API_REVISION });
-  const userRequest = wk.user.get();
+  const factory = new WK.ApiRequestFactory({ apiToken: WANIKANI_API_TOKEN, revision: WK_API_REVISION });
+  const userRequest = factory.user.get();
   const { method, headers } = userRequest;
   let { url } = userRequest;
   const init = { headers };
   let response = await fetch(url, init);
-  const user = (await response.json()) as WKError | WKUser;
-  if (typeof user.data === "undefined") {
-    throw new Error(user.error);
-  }
-  const batchSize = user.data.preferences.lessons_batch_size;
-  const ordering = user.data.preferences.lessons_presentation_order;
-
-  const assignmentParams: WKAssignmentParameters = {
-    immediately_available_for_lessons: true,
-  };
-
-  const assignmentRequest = wk.assignments.get(assignmentParams);
-
-  url = assignmentRequest.url;
-  response = await fetch(url, init);
-  let assignments = (await response.json()) as WKAssignmentCollection | WKError;
-  if (typeof assignments.data === "undefined" || typeof assignments.pages === "undefined") {
-    throw new Error(assignments.error);
-  }
-  const lessonData: WaniKaniLesson[] = [];
-  let moreAssignments = true;
-  while (moreAssignments) {
-    const ids: number[] = [];
-    assignments.data.forEach((assignment) => {
-      ids.push(assignment.data.subject_id);
-    });
-    const subjectParams: WKSubjectParameters = {
-      ids,
+  const user = await response.json();
+  if (WK.isUser(user)) {
+    const lessonData: WaniKaniLesson[] = [];
+    const batchSize = user.data.preferences.lessons_batch_size;
+    const assignmentParams: WK.AssignmentParameters = {
+      immediately_available_for_lessons: true,
     };
-    url = wk.subjects.get(subjectParams);
+    const assignmentRequest = factory.assignments.get(assignmentParams);
+    url = assignmentRequest.url;
     response = await fetch(url, init);
-    const subjects = (await response.json()) as WKSubjectCollection | WKError;
-    if (typeof subjects.data === "undefined") {
-      throw new Error(subjects.error);
-    } else {
-      if (ordering === "shuffled") {
-        // Durstenfeld shuffle
-        for (let i = assignments.data.length - 1; i > 0; i--) {
-          const j = Math.floor(Math.random() * (i + 1));
-          [assignments.data[i], assignments.data[j]] = [assignments.data[j], assignments.data[i]];
-        }
+    let assignments = await response.json();
+    let moreAssignments = true;
+    while (moreAssignments) {
+      if (WK.isAssignmentCollection(assignments)) {
+        const ids: number[] = [];
         assignments.data.forEach((assignment) => {
-          const subject = subjects.data.find((subject) => {
-            return subject.id === assignment.data.subject_id;
-          });
-          if (typeof subject === "undefined") {
-            throw new Error("Unexpected missing subject from collection!");
-          }
-          lessonData.push({
-            assignment: assignment.data,
-            subject: subject.data,
-          });
+          ids.push(assignment.data.subject_id);
         });
-      } else {
-        const levels: WaniKaniLessonLevels = {};
-        assignments.data.forEach((assignment) => {
-          const subject = subjects.data.find((subject) => {
-            return subject.id === assignment.data.subject_id;
-          });
-          if (typeof subject === "undefined") {
-            throw new Error("Unexpected missing subject from collection!");
-          }
-          if (typeof levels[subject.data.level] === "undefined") {
-            levels[subject.data.level] = [];
-          }
-          levels[subject.data.level]?.push({
-            assignment: assignment.data,
-            subject: subject.data,
-          });
-        });
-        for (const [_key, value] of Object.entries(levels)) {
-          if (ordering === "ascending_level_then_shuffled") {
-            for (let i = value.length - 1; i > 0; i--) {
-              const j = Math.floor(Math.random() * (i + 1));
-              [value[i], value[j]] = [value[j], value[i]];
+        const subjectParams: WK.SubjectParameters = {
+          ids,
+        };
+        url = factory.subjects.get(subjectParams);
+        response = await fetch(url, init);
+        const subjects = await response.json();
+        if (WK.isSubjectCollection(subjects)) {
+          const levels: WaniKaniLessonLevels = {};
+          assignments.data.forEach((assignment) => {
+            const subject = subjects.data.find((subject) => subject.id === assignment.data.subject_id);
+            if (typeof subject === "undefined") {
+              throw new Error("Unexpected missing subject from collection!");
             }
-          } else if (ordering === "ascending_level_then_subject") {
-            value.sort((lessonA, lessonB) => {
-              return lessonA.subject.lesson_position - lessonB.subject.lesson_position;
+            if (typeof levels[subject.data.level] === "undefined") {
+              levels[subject.data.level] = [];
+            }
+            levels[subject.data.level]?.push({
+              assignment,
+              subject,
             });
-          }
-          value.forEach((lesson) => {
-            lessonData.push(lesson);
           });
+          for (const [_key, value] of Object.entries(levels)) {
+            value
+              .sort((lessonA, lessonB) => {
+                return lessonA.subject.lesson_position - lessonB.subject.lesson_position;
+              })
+              .forEach((lesson) => {
+                lessonData.push(lesson);
+              });
+          }
+        } else if (WK.isApiError(subjects)) {
+          throw new Error(subjects.error);
+        } else {
+          throw new Error("Unknown WaniKani API Error when Getting Subjects");
         }
-      }
-    }
-    if (typeof assignments.pages !== "undefined" && assignments.pages.next_url !== null) {
-      url = assignments.pages.next_url;
-      response = await fetch(url, init);
-      assignments = (await response.json()) as WKAssignmentCollection | WKError;
-      if (typeof assignments.data === "undefined") {
+        if (typeof assignments.pages !== "undefined" && assignments.pages.next_url !== null) {
+          url = assignments.pages.next_url;
+          response = await fetch(url, init);
+          assignments = await response.json();
+        } else {
+          moreAssignments = false;
+        }
+      } else if (WK.isApiError(assignments)) {
         throw new Error(assignments.error);
+      } else {
+        throw new Error("Unknown WaniKani API Error when Getting Assignments");
       }
-    } else {
-      moreAssignments = false;
     }
+    return lessonData.slice(0, batchSize);
+  } else if (WK.isApiError(user)) {
+    throw new Error(user.error);
+  } else {
+    throw new Error("Unknown WaniKani API Error when Getting User");
   }
-  return lessonData.slice(0, batchSize);
 }
 ```
 
@@ -267,8 +219,8 @@ import {
   type WKAssignment,
   type WKAssignmentPayload,
   type WKDatableString,
-  type WKError,
-  WKRequestFactory,
+  type ApiError,
+  ApiRequestFactory,
   WK_API_REVISION,
   isWKDatableString,
 } from "@bachman-dev/wanikani-api-types/v20170710";
@@ -282,7 +234,7 @@ async function startAssignment(id: number, started_at?: WKDatableString | Date):
       },
     };
   }
-  const request = new WKRequestFactory({ apiToken: WANIKANI_API_TOKEN, revision: WK_API_REVISION }).assignments.start(
+  const request = new ApiRequestFactory({ apiToken: WANIKANI_API_TOKEN, revision: WK_API_REVISION }).assignments.start(
     id,
     payload,
   );
@@ -297,7 +249,7 @@ async function startAssignment(id: number, started_at?: WKDatableString | Date):
     const assignment = (await response.json()) as WKAssignment;
     return assignment;
   } else {
-    const error = (await response.json()) as WKError;
+    const error = (await response.json()) as ApiError;
     throw new Error(error.error);
   }
 }
@@ -311,8 +263,8 @@ Later that day, when a review is available, create it against the started assign
 import {
   type WKCreatedReview,
   type WKDatableString,
-  type WKError,
-  WKRequestFactory,
+  type ApiError,
+  ApiRequestFactory,
   type WKReviewPayload,
   WK_API_REVISION,
   isWKDatableString,
@@ -348,7 +300,7 @@ async function createReview(
     payload.review.created_at = created_at;
   }
 
-  const request = new WKRequestFactory({ apiToken: WANIKANI_API_TOKEN, revision: WK_API_REVISION }).reviews.create(
+  const request = new ApiRequestFactory({ apiToken: WANIKANI_API_TOKEN, revision: WK_API_REVISION }).reviews.create(
     payload,
   );
 
@@ -363,7 +315,7 @@ async function createReview(
     const createdReview = (await response.json()) as WKCreatedReview;
     return createdReview;
   } else {
-    const error = (await response.json()) as WKError;
+    const error = (await response.json()) as ApiError;
     throw new Error(error.error);
   }
 }

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022, 2023 Collin Bachman
+Copyright (c) 2022, 2023, 2024, 2025 Collin Bachman
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # @bachman-dev/wanikani-api-types
 
 [![Tests (Main)](https://github.com/bachman-dev/wanikani-api-types/actions/workflows/push.yml/badge.svg)](https://github.com/bachman-dev/wanikani-api-types/actions/workflows/push.yml)
-[![codecov](https://codecov.io/gh/bachman-dev/wanikani-api-types/branch/main/graph/badge.svg?token=CCVBE1UM9M)](https://codecov.io/gh/bachman-dev/wanikani-api-types)
+[![codecov](https://codecov.io/gh/bachman-dev/wanikani-api-types/graph/badge.svg?token=CCVBE1UM9M)](https://codecov.io/gh/bachman-dev/wanikani-api-types)
 
 Regularly updated type definitions for the [WaniKani API](https://docs.api.wanikani.com/20170710/)
 
@@ -21,8 +21,8 @@ A new Major Version x includes backwards-incompatible changes such as removing p
 
 | Package Version | TypeScript Versions | WaniKani API Version | Latest API Revision |
 | --------------- | ------------------- | -------------------- | ------------------- |
-| 2.x             | 5.0 - 5.7           | 2                    | 20170710            |
-| 1.x             | 4.5 - 5.7           | 2                    | 20170710            |
+| 2.x             | 5.0 - 5.8           | 2                    | 20170710            |
+| 1.x             | >= 4.5              | 2                    | 20170710            |
 
 ## Install
 
@@ -60,11 +60,7 @@ Then, import using one of two methods.
 The module you import from matches a [WaniKani API Revision](https://docs.api.wanikani.com/20170710/#revisions-aka-versioning); you shouldn't expect any breaking changes from the package.
 
 ```typescript
-import {
-  type WKAssignmentParameters,
-  type WKDatableString,
-  stringifyParameters,
-} from "@bachman-dev/wanikani-api-types/v20170710";
+import * as WK from "@bachman-dev/wanikani-api-types/v20170710";
 ```
 
 #### Latest API Revision (Not Recommended)
@@ -72,11 +68,7 @@ import {
 Importing from the index module will always provide types, methods, etc. for use with the latest and greatest API Revision.
 
 ```typescript
-import {
-  type WKAssignmentParameters,
-  type WKDatableString,
-  stringifyParameters,
-} from "@bachman-dev/wanikani-api-types";
+import * as WK from "@bachman-dev/wanikani-api-types";
 ```
 
 </details>
@@ -96,11 +88,11 @@ You can import the modules directly with `esm.sh`.
 The module you import from matches a [WaniKani API Revision](https://docs.api.wanikani.com/20170710/#revisions-aka-versioning); you shouldn't expect any breaking changes from the package.
 
 ```typescript
-import type {
-  WKAssignmentParameters,
-  WKDatableString,
+import {
+  type AssignmentParameters,
+  DatableString,
 } from "https://esm.sh/@bachman-dev/wanikani-api-types@x.y.z/v20170710";
-import { stringifyParameters } from "https://esm.sh/@bachman-dev/wanikani-api-types@x.y.z/v20170710";
+import { ApiRequestFactory } from "https://esm.sh/@bachman-dev/wanikani-api-types@x.y.z/v20170710";
 ```
 
 #### Latest API Revision (Not Recommended)
@@ -108,8 +100,8 @@ import { stringifyParameters } from "https://esm.sh/@bachman-dev/wanikani-api-ty
 Importing from the index module will always provide types, methods, etc. for use with the latest and greatest API Revision.
 
 ```typescript
-import type { WKAssignmentParameters, WKDatableString } from "https://esm.sh/@bachman-dev/wanikani-api-types@x.y.z";
-import { stringifyParameters } from "https://esm.sh/@bachman-dev/wanikani-api-types@x.y.z";
+import { type AssignmentParameters, DatableString } from "https://esm.sh/@bachman-dev/wanikani-api-types@x.y.z";
+import { ApiRequestFactory } from "https://esm.sh/@bachman-dev/wanikani-api-types@x.y.z";
 ```
 
 </details>
@@ -122,31 +114,24 @@ We provide various type definitions to help with sending/receiving type-safe ele
 
 - **Base Types** that define essential WaniKani API building blocks
 - **Collections/Reports/Resources** that represent whole responses from the API
-- **Data** that represents only the actual returned data from the API (i.e. the `data` field on most responses)
 - **Parameter Types** that can be broken down into a query string to append to a URI for the API (especially when fetching Collections) -- see below.
 - **Payloads** that represent JSON bodies sent to the API when creating/updating certain resources
 
-We also export various subtypes that fall underneath these main types, in case they're needed to work with partial data.
+## Schema Validation
+
+If you need to validate data going to/from the WaniKani API at runtime, you can use matching [Valibot](https://valibot.dev) schema provided for every exported type to do so; these schema are also compatible with any [Standard Schema](https://standardschema.dev/) compatible application/library.
 
 ### Type Guards
 
-Most of the types defined here are object types with straightforward structure. Sometimes, however, you may have a string or number that needs to meet specific criteria to be narrowed down to an exact type. So we provide some [type guards](https://www.typescriptlang.org/docs/handbook/2/narrowing.html#using-type-predicates) to verify if a variable is of a given type; these will usually begin with `is` in their name (e.g. `isWKDatableString`). See the documentation for more info.
+For all the types representing items coming from the WaniKani API, we provide type guards to quickly validate if the data matches a type (e.g. a WaniKani resource, or an API error if something went wrong), without producing any side-effects to keep your application's bundle size small.
 
 ## Request Factory
 
-We provide a special class, `WKRequestFactory`, that returns Request objects with all the information you need to make a request to the WaniKani API. That means the request's method (`GET`, `POST`, `PUT`), the URL (with parameters for Collections or an ID for individual Resources), headers (Authorization, conditional headers, etc.), and a body if you are sending data. You can use these objects in your preferred HTTP API/Library such as the Fetch API, Axios, Needle, Node's `https` Module, etc.
+We provide a special class, `ApiRequestFactory`, that returns Request objects with all the information you need to make a request to the WaniKani API. That means the request's method (`GET`, `POST`, `PUT`), the URL (with parameters for Collections or an ID for individual Resources), headers (Authorization, conditional headers, etc.), and a body if you are sending data. You can use these objects in your preferred HTTP API/Library such as the Fetch API, Axios, Needle, Node's `https` Module, etc.
 
-### Helper Functions
+### Markup Matcher
 
-There are also multiple helper functions that can assist with formatting and/or validating data sent to the WaniKani API, outside of and in addition to the Request Factory.
-
-- `stringifyParameters` converts a Parameters object (e.g. `WKAssignmentParameters`) into a URL query string to use when filtering a Collection
-- `validateParameters` does runtime validation on a Parameters object, allowing for more strict validation than TypeScript's type narrowing behavior (i.e. not allowing widening to `WKCollectionParameters`); it's a good function for those who must be absolutely sure their parameters are of the exact type.
-- `validatePayload` does runtime validation of Payload objects; while most TypeScript and editor-assisted projects likely won't need this function, it can be useful for pure JavaScript applications.
-
-### Markup Matchers
-
-When working with WaniKani's Subjects, you may want to stylize/highlight the markup that's inside the reading/meaning mnemonics and hints. We provide some Regex Literals that can be used to extract one or more of these sorts of markup in `WK_SUBJECT_MARKUP_MATCHERS`.
+When working with WaniKani's Subjects, you may want to stylize/highlight the markup that's inside the reading/meaning mnemonics and hints. We provide a Regex literal that can be used to extract one or more of these sorts of markup in `SUBJECT_MARKUP_MATCHER`.
 
 ### Examples
 
@@ -160,7 +145,7 @@ That said, if you have any questions or encounter any problems with this package
 
 We welcome any contributions to help improve this library. Please see the following documents:
 
-- [CONTRIBUTING.md](CONTRIBUTING.md)
-- [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)
+- [https://github.com/bachman-dev/wanikani-api-types/blob/main/CONTRIBUTING.md](CONTRIBUTING.md)
+- [https://github.com/bachman-dev/wanikani-api-types/blob/main/CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)
 
 Thank you in advance for your contribution(s)!

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,6 @@
+---
+title: Upgrade Guide
+category: Guides
+---
+
+# Upgrade Guide

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -81,6 +81,8 @@ The following items were renamed in Version 2 beyond just having a `WK` prefix r
 | ------------------- | ----------------- |
 | `WKCollection`      | `BaseCollection`  |
 | `WKError`           | `ApiError`        |
+| `WKReport`          | `BaseReport`      |
+| `WKResource`        | `BaseResource`    |
 | `WK_MAX_LEVELS`     | `MAX_LEVEL`       |
 | `WK_MIN_LEVELS`     | `MIN_LEVEL`       |
 | `isWKDatableString` | `isDatableString` |
@@ -90,12 +92,13 @@ The following items were renamed in Version 2 beyond just having a `WK` prefix r
 The following items were removed from Version 2:
 
 - All data types (e.g. `WKUserData`, `WKAssignmentData`, etc.), with the exception of subjects (see renamed items above), as they made testing type and schema validation more difficult, and were less likely to be used vs the entire object they were a part of; subject data types were kept as they are part of a discriminated union for mixed subjects returned from WaniKani.
-- `WKCollectionParametersMap` which was only used by `validateParameters()` which was also removed (see below)
+- `WKCollectionParametersMap` and `WKPayloadMap`, which were only used by `validateParameters()` and `validatePayload()` respectively which were also removed (see below)
 - The type aliases `WKMaxLessonBatchSize`, `WKMaxLevels`, `WKMaxSrsReviewStages`, `WKMaxSrsStages`, `WKMinLessonBatchSize`, and `WKMinLevels` were all removed in favor of using their constant equivalents.
+- `validateParameters()` and `validatePayload()` were removed in favor of using the request factory to construct a request to the API, now named {@link ApiRequestFactory}
 
-#### `data` Union Removed from `BaseCollection`
+#### `data` Property Removed from `BaseCollection`, `BaseReport`, and `BaseResource`
 
-Formerly `WKCollection`, this type had a `data` property that was a union of different typed arrays of WaniKani resources. This was removed, as there isn't a way to get multiple resource collections at once from WaniKani, nor would it be at all common to merge them together under this type like this in code.
+Formerly `WKCollection`, `WKReport`, and `WKResource` respectively, these types had a `data` property that was a union of different typed arrays of data for items that extended these types. This was removed, as it didn't align well with how the data was actually presented by the WaniKani API, ie there isn't a way to get different collections, reports, or resources in one go via the API.
 
 #### `DatableString` Now Uses Valibot Brand
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -45,7 +45,7 @@ Due to our introducing Valibot schema (see further down), importing items withou
 
 #### Unionizing `never` Properties Removed
 
-Some types in Version 1 had `never` interfaces in an attempt to make them easier to unionize with a WaniKani API Error; these properties have been removed in favor of using type guards / schema validation.
+Some types in Version 1 had `never` typed properties in an attempt to make them easier to unionize with a WaniKani API Error; these properties have been removed in favor of using type guards / schema validation.
 
 #### `WK` Prefix Removed from Items
 
@@ -100,10 +100,10 @@ The following items were renamed in Version 2 beyond just having a `WK` prefix r
 
 The following items were removed from Version 2:
 
-- All data types (e.g. `WKUserData`, `WKAssignmentData`, etc.), with the exception of subjects (see renamed items above), as they made testing type and schema validation more difficult, and were less likely to be used vs the entire object they were a part of; subject data types were kept as they are part of a discriminated union for mixed subjects returned from WaniKani.
+- All data types (e.g. `WKUserData`, `WKAssignmentData`, etc.), with the exception of subjects (`RadicalData`, `KanjiData`, etc.), as they made testing type and schema validation more difficult, and were less likely to be used vs the entire object they were a part of; subject data types were kept as they are part of a discriminated union for mixed subjects returned from WaniKani.
 - `WKCollectionParametersMap` and `WKPayloadMap`, which were only used by `validateParameters()` and `validatePayload()` respectively which were also removed (see below)
 - The type aliases `WKMaxLessonBatchSize`, `WKMaxLevels`, `WKMaxSrsReviewStages`, `WKMaxSrsStages`, `WKMinLessonBatchSize`, and `WKMinLevels` were all removed in favor of using their constant equivalents.
-- `WKResourceType`, as it's unlikely that code would need to use this union when working with the WaniKani API, ie these resources aren't gathered at once from the API
+- `WKResourceType`, as it's unlikely that code would need to use this union when working with the WaniKani API, ie these resources aren't gathered at the same time from the API
 - `WKRequestPostPutOptions` in favor of using `ApiRequestOptions` (formerly `WKRequestGetOptions`) for all request types, as all requests now only accept a `customHeaders` option instead of dedicated header options for `ifModifiedSince` and/or `ifNoneMatch` (see below)
 - `WKAssignmentRequests`, `WKLevelProgressionRequests`, `WKResetRequests`, `WKReviewRequests`, `WKReviewStatisticRequests`, `WKSpacedRepetitionSystemRequests`, `WKStudyMaterialRequests`, `WKSubjectRequests`, `WKSummaryRequests`, `WKUserRequests`, and `WKVoiceActorRequests` were all removed when the request factory was rewritten to use `public readonly` objects instead of accessors; these types were likely only used by the library itself
 - `WKReviewObjectdBase`, `WKReviewObjectWithAssignmentId`, and `WKReviewObjectWithSubjectId` in favor of directly expressing the union of allowed IDs under `ReviewPayload` (formerly `WKReviewPayload`)
@@ -113,11 +113,11 @@ The following items were removed from Version 2:
 
 #### `data` Property Removed from `BaseCollection`, `BaseReport`, and `BaseResource`
 
-Formerly `WKCollection`, `WKReport`, and `WKResource` respectively, these types had a `data` property that was a union of different typed arrays of data for items that extended these types. This was removed, as it didn't align well with how the data was actually presented by the WaniKani API, ie there isn't a way to get different collections, reports, or resources in one go via the API.
+Formerly `WKCollection`, `WKReport`, and `WKResource` respectively, these types had a `data` property that was a union of different typed data for items that extended these types. These were removed, as they didn't align well with how the data was actually presented by the WaniKani API, ie there isn't a way to get different collections, reports, or resources in one go via the API.
 
 #### `DatableString` Now Uses Valibot Brand
 
-In Version 1, we used our own `Brand` internal type to prevent creating `WKDatableString`s, and further assert they were for dates returned by WaniKani. Now that we use Valibot to parse them, the type now uses Valibot's built-in brand type instead.
+In Version 1, we used our own `Brand` internal type to prevent creating a `WKDatableString`, and further assert they were for dates returned by WaniKani. Now that we use Valibot to parse them (and thus optionally create them outside of the WaniKani API), the type now uses Valibot's built-in brand type instead.
 
 #### `MIN_LEVEL` Now Lowest WaniKani Level
 
@@ -142,7 +142,7 @@ These options were removed to make the code simpler when constructing headers fo
 
 #### `ApiRequestFactory` Methods Now Throw `ValiError`
 
-The methods for creating requests in the `ApiRequestFactory` (formerly `WKRequestFactory`) now perform additional validation on IDs when requesting individual resources, such as safe integer validation, and therefore may throw a `ValiError` in addition to a `TypeError`. This is reflected by the parameter being a `SafeInteger` instead of a plain `number`. More info on this new type is further down in the next parent section.
+The methods for creating requests in the `ApiRequestFactory` (formerly `WKRequestFactory`) now perform additional validation on IDs when requesting individual resources, such as safe integer validation, and therefore may throw a `ValiError` in addition to a `TypeError`, which is throw when type-checked headers are invalid. This is reflected by the parameter being a `SafeInteger` instead of a plain `number`. More info on this new type is further down in the next parent section.
 
 #### `ApiRequestFactory` Uses `public readonly` Objects Instead of Accessors
 
@@ -150,7 +150,7 @@ This change is mostly internal, but is mentioned in case it causes breaking chan
 
 #### `characters` Property No Longer in Subject Base
 
-`WKSubjectData` included a `characters` property that was extended on `WKRadicalData` to be `string | null`, and `string` on other subject types. This was removed on the base interface, and is now only present on the subject data types themselves. This does not affect code that was using the intefaces that extended the base interface.
+`WKSubjectData` included a `characters` property that was extended on `WKRadicalData` to be `string | null`, and `string` on other subject type in Version 1. This was removed on the base interface, and is now only present on the subject data types themselves. This does not affect code that was using the intefaces that extended the base interface.
 
 #### `Subject` is Now a Discriminated Union
 
@@ -215,7 +215,7 @@ if (isAssignment(assignment)) {
 
 #### Number Types Widened
 
-Both constants and type aliases for numbers (e.g. `Level`, `MIN_LEVEL`, `LessonBatchSizeNumber`, the `starting_srs_stage` and `ending_srs_stage` on reviews, etc.) have had their types widened. Constants are now plain number literals with type `number` instead of their corresponding type alias, and type aliases / interface properties were widened to `number & {}` typed type aliases so they show up in documentation. This allows for easier use of dynamically figured numbers in code. Type guards and schema should be used to validate these numbers; they are validated when used in `ApiRequestFactory`, e.g. when creating a request with `CollectionParameters`.
+Both constants and type aliases for numbers (e.g. `Level`, `MIN_LEVEL`, `LessonBatchSizeNumber`, the `starting_srs_stage` and `ending_srs_stage` on reviews, etc.) have had their types widened. Constants are now plain number literals with type `number` instead of their corresponding type alias, and type aliases / interface properties were widened to `number & {}` type aliases so they show up in documentation. This allows for easier use of dynamically calculated numbers in code. Type guards and schema should be used to validate these numbers; they are validated when used in `ApiRequestFactory`, e.g. when creating a request with `CollectionParameters`.
 
 #### `SafeInteger` Type for Validated Numbers
 
@@ -223,4 +223,4 @@ Some numbers, such as resource IDs, are validated to make sure they are a safe i
 
 #### Subject Markup Parser
 
-A new method, {@link parseSubjectMarkup}, can be used to parse a WaniKani subject mnemonic/hint with subject markup tags into an array of `ParsedSubjectMarkup` nodes, which can be traversed to construct HTML, JSX, and other UI components based on the markup for rendering.
+A new method, {@link parseSubjectMarkup}, can be used to parse a WaniKani subject mnemonic/hint with subject markup tags into an array of {@link ParsedSubjectMarkup} nodes, which can be traversed to construct HTML, JSX, and other UI components based on the markup for rendering.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -4,3 +4,64 @@ category: Guides
 ---
 
 # Upgrade Guide
+
+This guide contains advice and considerations when upgrading this library between major versions.
+
+Headings marked with a ⚠️ indicate breaking changes that may require code changes.
+
+## Version 1.x to 2.0
+
+Version 2.0 of the library introduced several breaking changes including renamed and removed items, but also introduced some new features that are especially helpful for runtime validation of data going to/from the WaniKani API.
+
+### General Changes
+
+#### ⚠️ Minimum TypeScript Version 5.0
+
+While the library itself doesn't make use of any features requiring 5.0, it is easier to build when we use 5.0 as a minimum version. This combined with the version being released in March 2023 and being widely adopted made it a good minimum version for the typescript peerDependency.
+
+#### `typescript` peerDependency is now optional
+
+When Version 1 of the library was released, it consisted mostly of TypeScript types, so it made sense, in our opinion at the time anyway, to have TypeScript be a required peerDependency; it's since been made optional with the addition of more runtime code, particularly schema and type guards.
+
+#### ⚠️ Library Targets ES2022
+
+We use a new indices (d) flag in a regular expression that requires running on an ES2022 or higher runtime. All major browsers and JS runtimes (Node, Deno, Bun, etc.) support these features.
+
+#### ⚠️ Exports Are Officially ESM Only
+
+In Version 1, we didn't have an actual policy on whether we supported alternate module systems like CommonJS. In Version 2, we're making it official policy that we'll only be supporting ECMAScript Modules (ESM) as an exported format; while it may be possible to use the library in a CommonJS setting, we aren't able to easily accommodate it.
+
+#### ⚠️ Change to `v20170710` Module
+
+When we published Version 1, the export configuration for the package's modules was valid but not ideal; it pointed to a relative path of the package instead of a module name. Those using the `v20170710` module will need to update their imports to use the new module like so:
+
+```diff
+- import {} from  "@bachman-dev/wanikani-api-types/dist/v20170710";
++ import {} from  "@bachman-dev/wanikani-api-types/v20170710";
+```
+
+#### ⚠️ `WK` Prefix Removed from Items
+
+Unless otherwise noted below, most items have only had their `WK` prefix removed in terms of renaming.
+
+```diff
+- import { WKAssignmentParameters } from "@bachman-dev/wanikani-api-types/dist/v20170710";
++ import { AssignmentParameters } from "@bachman-dev/wanikani-api-types/v20170710";
+
+- const params: WKAssignmentParameters = {};
++ const params: AssignmentParameters = {};
+```
+
+Items can be imported using a namespaced / wildcard import with a prefix (`WK` or otherwise) if one is desired.
+
+```diff
+- import { WKAssignmentParameters } from "@bachman-dev/wanikani-api-types/dist/v20170710";
++ import * as WK from "@bachman-dev/wanikani-api-types/v20170710";
+
+- const params: WKAssignmentParameters = {};
++ const params: WK.AssignmentParameters = {};
+```
+
+#### ⚠️ Most Resource `Data` Types Removed
+
+With the exception of Radicals, Kanji, Vocabulary, and Kana Vocabulary, all other `Data` types have been removed. These types were based on data returned from WaniKani, and were never meant to be initialized by clients; removing them reduced the complexity of tests written for matching runtime schemas and types. For most users, this will only effect things like how the type appears in their editor; those who used these types e.g. in type annotations/parameters/etc. will need to refactor their code.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -7,31 +7,25 @@ category: Guides
 
 This guide contains advice and considerations when upgrading this library between major versions.
 
-Headings marked with a ⚠️ indicate breaking changes that may require code changes.
-
 ## Version 1.x to 2.0
 
 Version 2.0 of the library introduced several breaking changes including renamed and removed items, but also introduced some new features that are especially helpful for runtime validation of data going to/from the WaniKani API.
 
-### General Changes
+### ⚠️ Breaking Changes
 
-#### ⚠️ Minimum TypeScript Version 5.0
+#### Minimum TypeScript Version 5.0
 
 While the library itself doesn't make use of any features requiring 5.0, it is easier to build when we use 5.0 as a minimum version. This combined with the version being released in March 2023 and being widely adopted made it a good minimum version for the typescript peerDependency.
 
-#### `typescript` peerDependency is now optional
-
-When Version 1 of the library was released, it consisted mostly of TypeScript types, so it made sense, in our opinion at the time anyway, to have TypeScript be a required peerDependency; it's since been made optional with the addition of more runtime code, particularly schema and type guards.
-
-#### ⚠️ Library Targets ES2022
+#### Library Targets ES2022
 
 We use a new indices (d) flag in a regular expression that requires running on an ES2022 or higher runtime. All major browsers and JS runtimes (Node, Deno, Bun, etc.) support these features.
 
-#### ⚠️ Exports Are Officially ESM Only
+#### Exports Are Officially ESM Only
 
 In Version 1, we didn't have an actual policy on whether we supported alternate module systems like CommonJS. In Version 2, we're making it official policy that we'll only be supporting ECMAScript Modules (ESM) as an exported format; while it may be possible to use the library in a CommonJS setting, we aren't able to easily accommodate it.
 
-#### ⚠️ Change to `v20170710` Module
+#### Change to `v20170710` Module
 
 When we published Version 1, the export configuration for the package's modules was valid but not ideal; it pointed to a relative path of the package instead of a module name. Those using the `v20170710` module will need to update their imports to use the new module like so:
 
@@ -40,7 +34,7 @@ When we published Version 1, the export configuration for the package's modules 
 + import {} from  "@bachman-dev/wanikani-api-types/v20170710";
 ```
 
-#### ⚠️ `WK` Prefix Removed from Items
+#### `WK` Prefix Removed from Items
 
 Unless otherwise noted below, most items have only had their `WK` prefix removed in terms of renaming.
 
@@ -62,6 +56,12 @@ Items can be imported using a namespaced / wildcard import with a prefix (`WK` o
 + const params: WK.AssignmentParameters = {};
 ```
 
-#### ⚠️ Most Resource `Data` Types Removed
+#### Most Resource `Data` Types Removed
 
 With the exception of Radicals, Kanji, Vocabulary, and Kana Vocabulary, all other `Data` types have been removed. These types were based on data returned from WaniKani, and were never meant to be initialized by clients; removing them reduced the complexity of tests written for matching runtime schemas and types. For most users, this will only effect things like how the type appears in their editor; those who used these types e.g. in type annotations/parameters/etc. will need to refactor their code.
+
+### Other Enhancements to Consider
+
+#### `typescript` peerDependency is now optional
+
+When Version 1 of the library was released, it consisted mostly of TypeScript types, so it made sense, in our opinion at the time anyway, to have TypeScript be a required peerDependency; it's since been made optional with the addition of more runtime code, particularly schema and type guards.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -19,11 +19,11 @@ While the library itself doesn't make use of any features requiring 5.0, it is e
 
 #### Library Targets ES2022
 
-We use a new indices (d) flag in a regular expression that requires running on an ES2022 or higher runtime. All major browsers and JS runtimes (Node, Deno, Bun, etc.) support these features.
+We use a new indices (`d`) flag in a regular expression that requires running on an ES2022 or higher runtime. All major browsers and JS runtimes (Node, Deno, Bun, etc.) support these features in their recent versions.
 
 #### Exports Are Officially ESM Only
 
-In Version 1, we didn't have an actual policy on whether we supported alternate module systems like CommonJS. In Version 2, we're making it official policy that we'll only be supporting ECMAScript Modules (ESM) as an exported format; while it may be possible to use the library in a CommonJS setting, we aren't able to easily accommodate it.
+In Version 1, we didn't have an actual policy on whether we supported alternate module systems like CommonJS. In Version 2, we're making it official policy that we'll only be supporting ECMAScript Modules (ESM) as an exported format; while it may be possible to use the library in a CommonJS or other module setting, we aren't able to easily accommodate it.
 
 #### Change to `v20170710` Module
 
@@ -34,34 +34,130 @@ When we published Version 1, the export configuration for the package's modules 
 + import {} from  "@bachman-dev/wanikani-api-types/v20170710";
 ```
 
+#### Non-Type Import Side Effects
+
+Due to our introducing Valibot schema (see further down), importing items without using `import type` may lead to unintended side effects such as an increased bundle size. If only the type definition is needed, make sure to only import its type.
+
+```diff
+- import { /* ... */ } from "@bachman-dev/wanikani-api-types/dist/v20170710";
++ import type { /* ... */ } from "@bachman-dev/wanikani-api-types/v20170710";
+```
+
+#### Unionizing `never` Properties Removed
+
+Some types in Version 1 had `never` interfaces in an attempt to make them easier to unionize with a WaniKani API Error; these properties have been removed in favor of using type guards / schema validation.
+
 #### `WK` Prefix Removed from Items
 
 Unless otherwise noted below, most items have only had their `WK` prefix removed in terms of renaming.
 
 ```diff
-- import { WKAssignmentParameters } from "@bachman-dev/wanikani-api-types/dist/v20170710";
-+ import { AssignmentParameters } from "@bachman-dev/wanikani-api-types/v20170710";
+- import { type WKAssignmentParameters, WK_API_REVISION } from "@bachman-dev/wanikani-api-types/dist/v20170710";
++ import { type AssignmentParameters, API_REVISION } from "@bachman-dev/wanikani-api-types/v20170710";
 
 - const params: WKAssignmentParameters = {};
+- const apiYear = WK_API_REVISION.slice(0, 5);
 + const params: AssignmentParameters = {};
++ const apiYear = API_REVISION.slice(0, 5);
 ```
 
 Items can be imported using a namespaced / wildcard import with a prefix (`WK` or otherwise) if one is desired.
 
 ```diff
-- import { WKAssignmentParameters } from "@bachman-dev/wanikani-api-types/dist/v20170710";
+- import { type WKAssignmentParameters, WK_API_REVISION } from "@bachman-dev/wanikani-api-types/dist/v20170710";
 + import * as WK from "@bachman-dev/wanikani-api-types/v20170710";
 
 - const params: WKAssignmentParameters = {};
+- const apiYear = WK_API_REVISION.slice(0, 5);
 + const params: WK.AssignmentParameters = {};
++ const apiYear = WK.API_REVISION.slice(0, 5);
 ```
 
-#### Most Resource `Data` Types Removed
+#### Renamed Items
 
-With the exception of Radicals, Kanji, Vocabulary, and Kana Vocabulary, all other `Data` types have been removed. These types were based on data returned from WaniKani, and were never meant to be initialized by clients; removing them reduced the complexity of tests written for matching runtime schemas and types. For most users, this will only effect things like how the type appears in their editor; those who used these types e.g. in type annotations/parameters/etc. will need to refactor their code.
+The following items were renamed in Version 2 beyond just having a `WK` prefix removed:
+
+| Old Name            | New Name          |
+| ------------------- | ----------------- |
+| `WKCollection`      | `BaseCollection`  |
+| `WKError`           | `ApiError`        |
+| `WK_MAX_LEVELS`     | `MAX_LEVEL`       |
+| `WK_MIN_LEVELS`     | `MIN_LEVEL`       |
+| `isWKDatableString` | `isDatableString` |
+
+#### Removed Items
+
+The following items were removed from Version 2:
+
+- All data types (e.g. `WKUserData`, `WKAssignmentData`, etc.), with the exception of subjects (see renamed items above), as they made testing type and schema validation more difficult, and were less likely to be used vs the entire object they were a part of; subject data types were kept as they are part of a discriminated union for mixed subjects returned from WaniKani.
+- `WKCollectionParametersMap` which was only used by `validateParameters()` which was also removed (see below)
+- The type aliases `WKMaxLessonBatchSize`, `WKMaxLevels`, `WKMaxSrsReviewStages`, `WKMaxSrsStages`, `WKMinLessonBatchSize`, and `WKMinLevels` were all removed in favor of using their constant equivalents.
+
+#### `data` Union Removed from `BaseCollection`
+
+Formerly `WKCollection`, this type had a `data` property that was a union of different typed arrays of WaniKani resources. This was removed, as there isn't a way to get multiple resource collections at once from WaniKani, nor would it be at all common to merge them together under this type like this in code.
+
+#### `DatableString` Now Uses Valibot Brand
+
+In Version 1, we used our own `Brand` internal type to prevent creating `WKDatableString`s, and further assert they were for dates returned by WaniKani. Now that we use Valibot to parse them, the type now uses Valibot's built-in brand type instead.
+
+#### `MIN_LEVEL` Now Lowest WaniKani Level
+
+Formerly `WK_MIN_LEVELS` this constant now represents the smallest level, `1`, available in WaniKani, rather than the lowest level given to free-tier users without a subscription.
 
 ### Other Enhancements to Consider
+
+#### Items Moved in Documentation
+
+The following items changed file locations in Version 2, which meant a change in their documentation categories:
+
+| Item                                | Old Category | New Category              |
+| ----------------------------------- | ------------ | ------------------------- |
+| `LessonBatchSizeNumber`             | Base         | User                      |
+| `SpacedRepetitionSystemStageNumber` | Base         | Spaced Repetition Systems |
+| `SubjectTuple`                      | Base         | Subjects                  |
+| `SubjectType`                       | Base         | Subjects                  |
+| `MAX_LESSON_BATCH_SIZE`             | Base         | User                      |
+| `MAX_SRS_STAGE`                     | Base         | Spaced Repetition Systems |
+| `MAX_SRS_REVIEW_STAGE`              | Base         | Spaced Repetition Systems |
+| `MIN_LESSON_BATCH_SIZE`             | Base         | User                      |
+| `MIN_SRS_STAGE`                     | Base         | Spaced Repetition Systems |
 
 #### `typescript` peerDependency is now optional
 
 When Version 1 of the library was released, it consisted mostly of TypeScript types, so it made sense, in our opinion at the time anyway, to have TypeScript be a required peerDependency; it's since been made optional with the addition of more runtime code, particularly schema and type guards.
+
+#### Valibot Schema for Runtime Validation
+
+Every exported type now includes a matching Valibot schema, which can be used with any Valibot or [Standard Schema](https://standardschema.dev/) compatible application/library/etc.
+
+```ts
+import * as v from "valibot";
+import { Assignment } from "@bachman-dev/wanikani-api-types/v20170710";
+
+const response = await fetch(url);
+
+const data = await response.json();
+
+// Both the typedef and schema share a name here
+const assignment: Assignment = v.parse(Assignment, data);
+```
+
+#### Type Guards
+
+Every type returned from the WaniKani API now includes a type guard for runtime validation instead of merely asserting the type.
+
+```ts
+import { isAssignment } from "@bachman-dev/wanikani-api-types/v20170710";
+
+const response = await fetch(url, options);
+const assignment = await response.json();
+
+if (isAssignment(assignment)) {
+  const { object } = assignment; // "assignment"
+}
+```
+
+#### Number Types Widened
+
+Both constants and type aliases for numbers (e.g. `Level`, `MIN_LEVEL`, `LessonBatchSizeNumber`, etc.) have had their types widened. Constants are now plain number literals with type `number` instead of their corresponding type alias, and type aliases were widened to `number & {}` so they show up in documentation. This allows for easier use of dynamically figured numbers in code. Type guards and schema should be used to validate these numbers; they are validated when used in `ApiRequestFactory`, e.g. when creating a request with `CollectionParameters`.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -158,7 +158,7 @@ Formerly `WKSubject`, this type now uses the `object` field as a variant to crea
 
 #### `WK_SUBJECT_MARKUP_MATCHERS` Combined into `SUBJECT_MARKUP_MATCHER`
 
-In Version 1, this was an object with separate regex matchers for each individual subject markup tag found in mnemonics and hints in the WaniKani API. These have been combined into one matcher that matches on all the tags. In new `tag` capture group has been added to check the tag name, alongside the existing `innerText` group. The matcher also makes use of the `d` flag to provide start and end indices for matches and groups.
+In Version 1, this was an object with separate regex matchers for each individual subject markup tag found in mnemonics and hints in the WaniKani API. These have been combined into one matcher that matches on all the tags. A new `tag` capture group has been added to check the tag name, alongside the existing `innerText` group. The matcher also makes use of the `d` flag to provide start and end indices for matches and groups.
 
 ### Other Enhancements to Consider
 
@@ -223,4 +223,4 @@ Some numbers, such as resource IDs, are validated to make sure they are a safe i
 
 #### Subject Markup Parser
 
-A new method, `parseSubjectMarkup()`, can be used to parse a WaniKani subject mnemonic/hint with subject markup tags into an array of `ParsedSubjectMarkup` nodes, which can be traversed to construct HTML, JSX, and other UI components based on the markup for rendering.
+A new method, {@link parseSubjectMarkup}, can be used to parse a WaniKani subject mnemonic/hint with subject markup tags into an array of `ParsedSubjectMarkup` nodes, which can be traversed to construct HTML, JSX, and other UI components based on the markup for rendering.

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ Try sticking to imports from a specific revision.
 */
 
 /**
- * @module
+ * @packageDocumentation
  * @category API Reference
  */
 export * from "./v20170710/index.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,4 +3,8 @@ This file exports all the types available in the recommended API revision. There
 Try sticking to imports from a specific revision.
 */
 
+/**
+ * @module
+ * @category API Reference
+ */
 export * from "./v20170710/index.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,8 +3,4 @@ This file exports all the types available in the recommended API revision. There
 Try sticking to imports from a specific revision.
 */
 
-/**
- * @packageDocumentation
- * @category API Reference
- */
 export * from "./v20170710/index.js";

--- a/src/v20170710/index.ts
+++ b/src/v20170710/index.ts
@@ -1,3 +1,7 @@
+/**
+ * @module
+ * @category API Reference
+ */
 export * from "./assignments.js";
 export * from "./base.js";
 export * from "./level-progressions.js";

--- a/src/v20170710/index.ts
+++ b/src/v20170710/index.ts
@@ -1,5 +1,5 @@
 /**
- * @module
+ * @packageDocumentation
  * @category API Reference
  */
 export * from "./assignments.js";

--- a/src/v20170710/index.ts
+++ b/src/v20170710/index.ts
@@ -1,7 +1,8 @@
 /**
- * @packageDocumentation
+ * @module v20170710
  * @category API Reference
  */
+
 export * from "./assignments.js";
 export * from "./base.js";
 export * from "./level-progressions.js";

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://typedoc.org/schema.json",
-  "entryPoints": ["./src/v20170710/index.ts", "./src/index.ts"],
+  "entryPoints": ["./src/v20170710/index.ts"],
   "out": "docs",
   "plugin": ["./typedoc/plugin.js"],
   "router": "cloudflare",

--- a/typedoc.json
+++ b/typedoc.json
@@ -5,6 +5,7 @@
   "plugin": ["./typedoc/plugin.js"],
   "router": "cloudflare",
   "sourceLinkTemplate": "https://github.com/bachman-dev/wanikani-api-types/blob/{gitRevision}/{path}#L{line}",
+  "projectDocuments": ["./EXAMPLES.md", "./UPGRADE.md"],
   "externalSymbolLinkMappings": {
     "valibot": {
       "ValiError": "https://valibot.dev/api/ValiError/"

--- a/typedoc.json
+++ b/typedoc.json
@@ -11,6 +11,7 @@
       "ValiError": "https://valibot.dev/api/ValiError/"
     }
   },
+  "highlightLanguages": ["bash", "console", "diff", "javascript", "json", "jsonc", "typescript"],
   "cleanOutputDir": true,
   "includeVersion": true,
   "categorizeByGroup": false,

--- a/typedoc.json
+++ b/typedoc.json
@@ -11,7 +11,7 @@
       "ValiError": "https://valibot.dev/api/ValiError/"
     }
   },
-  "highlightLanguages": ["bash", "console", "diff", "javascript", "json", "jsonc", "typescript"],
+  "highlightLanguages": ["bash", "console", "diff", "javascript", "json", "jsonc", "typescript", "tsx"],
   "cleanOutputDir": true,
   "includeVersion": true,
   "categorizeByGroup": false,


### PR DESCRIPTION
# Description

This PR updates the EXAMPLES.md file, adds an Upgrade Guide for upgrading from 1.x to 2.0, and updates the TypeDoc configuration to render these guides on the documentation website.

# Related Issue(s) / Pull Request(s)

None

# Nature of Pull Request

This Pull Request:

- [ ] Adds/Updates Type(s) described in the WaniKani API Docs
- [ ] Adds/Updates Type(s) provided by the `wanikani-api-types` package itself
- [ ] Adds/Updates constants or other variables provided by the package
- [ ] Adds/Updates Helper Functions/Type Guards provided by the package
- [x] Updates Documentation
- [x] Updates Project and/or Community Health files (e.g. README, GitHub Actions, etc.)

Its changes constitutes a:

- [x] Non-code change (i.e. no version bump)
- [ ] Bug Fix or Other Small Changes (i.e. patch version bump)
- [ ] Forward-compatible Enhancement (i.e. minor version bump)
- [ ] ⚠️ BREAKING CHANGE regarding TypeScript, Package, and/or WaniKani API version(s) (i.e. MAJOR version bump)

# Additional Info

None

# Contribution Terms

I understand that by submitting this Pull Request:

- I agree to the terms outlined in the [Contribution Guidelines](https://github.com/bachman-dev/wanikani-api-types/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/bachman-dev/wanikani-api-types/blob/main/CODE_OF_CONDUCT.md)
- My code will be licensed for use in this repository per its [LICENSE](https://github.com/bachman-dev/wanikani-api-types/blob/main/LICENSE), and that I have the right to license this code -- per GitHub's [Terms of Service](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service#6-contributions-under-repository-license)
