### PR TITLE
Requests: Re-Add SRS Shorthand Property

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bachman-dev/wanikani-api-types",
-  "version": "2.0.0-beta.1",
+  "version": "2.0.0-rc.0",
   "description": "Regularly updated type definitions for the WaniKani API",
   "keywords": [
     "wanikani",

--- a/src/v20170710/requests.ts
+++ b/src/v20170710/requests.ts
@@ -320,6 +320,12 @@ export class ApiRequestFactory {
   };
 
   /**
+   * An alias for Spaced Repetition System requests.
+   * @see {@link ApiRequestFactory.spacedRepetitionSystems}
+   */
+  public readonly srs = this.spacedRepetitionSystems;
+
+  /**
    * Types of Study Material Requests available in the WaniKani API.
    */
   public readonly studyMaterials = {

--- a/src/v20170710/requests.ts
+++ b/src/v20170710/requests.ts
@@ -321,7 +321,6 @@ export class ApiRequestFactory {
 
   /**
    * An alias for Spaced Repetition System requests.
-   * @see {@link ApiRequestFactory.spacedRepetitionSystems}
    */
   public readonly srs = this.spacedRepetitionSystems;
 


### PR DESCRIPTION
# Description

This PR re-adds the `srs` property on `ApiRequestFactory` to serve as an alias for the longer `spacedRepetitionSystems` property. This was present in Version 1, and was originally going to be removed in V2, but I ultimately decided to keep it.

# Related Issue(s) / Pull Request(s)

None

# Nature of Pull Request

This Pull Request:

- [ ] Adds/Updates Type(s) described in the WaniKani API Docs
- [ ] Adds/Updates Type(s) provided by the `wanikani-api-types` package itself
- [x] Adds/Updates constants or other variables provided by the package
- [ ] Adds/Updates Helper Functions/Type Guards provided by the package
- [x] Updates Documentation
- [ ] Updates Project and/or Community Health files (e.g. README, GitHub Actions, etc.)

Its changes constitutes a:

- [ ] Non-code change (i.e. no version bump)
- [ ] Bug Fix or Other Small Changes (i.e. patch version bump)
- [x] Forward-compatible Enhancement (i.e. minor version bump)
- [ ] ⚠️ BREAKING CHANGE regarding TypeScript, Package, and/or WaniKani API version(s) (i.e. MAJOR version bump)

# Additional Info

None

# Contribution Terms

I understand that by submitting this Pull Request:

- I agree to the terms outlined in the [Contribution Guidelines](https://github.com/bachman-dev/wanikani-api-types/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/bachman-dev/wanikani-api-types/blob/main/CODE_OF_CONDUCT.md)
- My code will be licensed for use in this repository per its [LICENSE](https://github.com/bachman-dev/wanikani-api-types/blob/main/LICENSE), and that I have the right to license this code -- per GitHub's [Terms of Service](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service#6-contributions-under-repository-license)
