### PR TITLE
GitHub: Remove `v1` Branch

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,5 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>bachman-dev/renovate-config:jslib"],
-  "baseBranches": ["main", "v1"]
+  "extends": ["github>bachman-dev/renovate-config:jslib"]
 }

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -4,8 +4,6 @@ on:
   pull_request:
     branches:
       - main
-      - v1
-      - v2
     types:
       - opened
       - reopened

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - v1
 jobs:
   test:
     name: "Test Main Branch"


### PR DESCRIPTION
# Description

This PR updates project files so they don't reference the v1 branch we created shortly before merging the v2 branch into main. The branch has served its purpose in case the merge went poorly; if we need to push a new v1 release, we can checkout the latest 1.x tag and do so.

# Nature of Pull Request

This Pull Request:

- [ ] Adds/Updates Type(s)/Schemas
- [ ] Adds/Updates Helper Functions/Type Guards
- [ ] Updates Documentation
- [x] Updates Project and/or Community Health files (e.g. README, GitHub Actions, etc.)

Its changes constitutes a:

- [x] Non-code change (i.e. no version bump)
- [ ] Bug Fix or Other Small Changes (i.e. patch version bump)
- [ ] Forward-compatible Enhancement (i.e. minor version bump)
- [ ] ⚠️ BREAKING CHANGE regarding TypeScript, Package, and/or WaniKani API version(s) (i.e. MAJOR version bump)

# Contribution Terms

I understand that by submitting this Pull Request:

- I agree to the terms outlined in the [Contribution Guidelines](https://github.com/bachman-dev/wanikani-api-types/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/bachman-dev/wanikani-api-types/blob/main/CODE_OF_CONDUCT.md)
- My code will be licensed for use in this repository per its [LICENSE](https://github.com/bachman-dev/wanikani-api-types/blob/main/LICENSE), and that I have the right to license this code -- per GitHub's [Terms of Service](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service#6-contributions-under-repository-license)
